### PR TITLE
Addedinstallerfoldertotuestatus

### DIFF
--- a/setup/tue.bash_functions
+++ b/setup/tue.bash_functions
@@ -217,7 +217,8 @@ function tue-status
                 status=`svn status $pkg_dir`
                 vctype=svn
             else
-                # Try git				
+                # Try git
+
                 cd $pkg_dir
                 if [ "$f" == "~/.tue" ]
 				then


### PR DESCRIPTION
@svddries, ik heb tue-status script aangepast zodat hij ook in de .tue folder kijkt. 
Ik heb er een pull request voor aangemaakt omdat ik niet zeker weet of jij het hier mee eens bent. Ik heb bijvoorbeeld de locatie ~/.tue hardcoded, maar ik ga er vanuit dat die altijd op dezelfde plek staat. closes #3 
