### PR TITLE
remove tue_pocketsphinx from the middleware, fixes #6

### DIFF
--- a/installer/targets/tue-middleware/install.yaml
+++ b/installer/targets/tue-middleware/install.yaml
@@ -37,8 +37,6 @@
 - type: target
   name: ros-text_to_speech
 - type: target
-  name: ros-tue_pocketsphinx
-- type: target
   name: ros-speech_interpreter
 
 # World model


### PR DESCRIPTION
Can we remove `tue_pocketsphinx` from the launch files already or is it still needed? This will fix #6.