### PR TITLE
fix(): Added missing message definitions for websocket server

### DIFF
--- a/installer/targets/amigo-start/install.yaml
+++ b/installer/targets/amigo-start/install.yaml
@@ -30,3 +30,16 @@
 
 - type: target
   name: ros-head_ref
+
+# Additional mesage definitions required for websocket calls
+# This is why you should make separate message packages o.O
+- type: target
+  name: ros-image_recognition_msgs
+- type: target
+  name: ros-ed_robocup
+- type: target
+  name: ros-ed_sensor_integration
+- type: target
+  name: ros-cb_planner_msgs_srvs
+- type: target
+  name: ros-ed_perception


### PR DESCRIPTION
The ROSBridge websocket server that provides a websocket JSON API
requires the message definitions in order to construct the bridged
interfaces. Added the missing message definitions to amigo-start target
in order to make the web clients works fully.