### PR TITLE
restore rtt_tue_msgs target, but now in YAML

### DIFF
--- a/installer/targets/ros-rtt_tue_msgs/install.yaml
+++ b/installer/targets/ros-rtt_tue_msgs/install.yaml
@@ -1,0 +1,4 @@
+- type: ros
+  source:
+    type: git
+    url: https://github.com/tue-robotics/rtt_tue_msgs.git


### PR DESCRIPTION
rtt_control_components does depend on it. Rein will move the repo back from graveyard.