### PR TITLE
Revert "unset ROS_MASTER_URI"

### DIFF
--- a/installer/targets/robot-user/setup
+++ b/installer/targets/robot-user/setup
@@ -1,4 +1,4 @@
-alias local-core='unset ROS_MASTER_URI'
+alias local-core='export ROS_MASTER_URI=http://localhost:11311'
 
 ####################
 #


### PR DESCRIPTION
This reverts commit 9f6cbea558fedf15bf6d0c6e4527f062a8022330.
```
ROS master URI is not set
The traceback for the exception was written to the log file
```