### PR TITLE
remove old pycharm version

### DIFF
--- a/installer/targets/pycharm/install.bash
+++ b/installer/targets/pycharm/install.bash
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+pycharm="pycharm-community"
+if dpkg-query -W -f='${Status}' $pycharm 2>/dev/null | grep -q "ok installed"
+then
+    tue-install-debug "Pycharm was installed  by apt, removing it now"
+    sudo apt-get remove $pycharm
+else
+    tue-install-debug "Pycharm was not installed by apt"
+fi

--- a/installer/targets/pycharm/install.bash
+++ b/installer/targets/pycharm/install.bash
@@ -4,7 +4,7 @@ pycharm="pycharm-community"
 if dpkg-query -W -f='${Status}' $pycharm 2>/dev/null | grep -q "ok installed"
 then
     tue-install-debug "Pycharm was installed  by apt, removing it now"
-    sudo apt-get remove $pycharm
+    tue-install-warning "Pycharm is now installed via SNAP. To remove the old apt version: sudo apt-get remove $pycharm"
 else
     tue-install-debug "Pycharm was not installed by apt"
 fi


### PR DESCRIPTION
Pycharm is now installed by snap, directly from jetbrains. All PPA's are maintained by individuals. The PPA version was installed in an other location, than the snap. Therefore the PPA version needs to be removed.