### PR TITLE
use date_stamp for log instead of random id

### DIFF
--- a/installer/scripts/tue-install-impl
+++ b/installer/scripts/tue-install-impl
@@ -41,8 +41,8 @@ TUE_REPOS_DIR=$TUE_ENV_DIR/repos
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-function randid {
-    </dev/urandom tr -dc '0123456789abcdef' | head -c16; echo ""
+function date_stamp {
+    echo $(date +%Y_%m_%d_%H_%M_%S)
 }
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -553,7 +553,8 @@ function generate_setup_file
 #                                           MAIN LOOP
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-INSTALL_DETAILS_FILE=/tmp/tue-get-details-`randid`
+stamp=$(date_stamp)
+INSTALL_DETAILS_FILE=/tmp/tue-get-details-$stamp
 > $INSTALL_DETAILS_FILE
 
 # CATKIN PACKAGES
@@ -562,11 +563,8 @@ ROS_PACKAGE_INSTALL_DIR=$TUE_SYSTEM_DIR/src
 TUE_INSTALL_TARGET_DIR=$TUE_INSTALL_TARGETS_DIR
 TUE_INSTALL_SCRIPTS_DIR=$TUE_DIR/installer/scripts
 
-TUE_INSTALL_STATE_DIR=/tmp/tue-installer/`randid`
+TUE_INSTALL_STATE_DIR=/tmp/tue-installer/$stamp
 mkdir -p $TUE_INSTALL_STATE_DIR
-
-TUE_INSTALL_TEMP_DIR=/tmp/tue-installer/`randid`
-mkdir -p $TUE_INSTALL_TEMP_DIR
 
 TUE_INSTALL_GIT_PULL_Q=()
 


### PR DESCRIPTION
- for easy checking of last install run
- TUE_INSTALL_TEMP_DIR is the same as TUE_INSTALL_STATE_DIR and wasn't used