### PR TITLE
move old environment files

### DIFF
--- a/installer/scripts/bootstrap-ros-indigo
+++ b/installer/scripts/bootstrap-ros-indigo
@@ -3,9 +3,15 @@
 # make sure git is installed
 hash git 2> /dev/null || sudo apt-get install -y git
 
-if [ -e ~/.tue ]
+# Move old environments and installer
+if [[ -e ~/.tue && -z "$CI" ]]
 then
-	mv -f ~/.tue ~/.tue.$(date +%F_%R)
+    FILES=$(find ~/.tue/user/envs -maxdepth 1 -type f)
+    for env in $FILES
+    do
+        mv -f $(cat $env) $(cat $env).$(date +%F_%R)
+    done
+    mv -f ~/.tue ~/.tue.$(date +%F_%R)
 fi
 
 # Update installer

--- a/installer/scripts/bootstrap-ros-jade
+++ b/installer/scripts/bootstrap-ros-jade
@@ -3,9 +3,15 @@
 # make sure git is installed
 hash git 2> /dev/null || sudo apt-get install -y git
 
-if [ -e ~/.tue ]
+# Move old environments and installer
+if [[ -e ~/.tue && -z "$CI" ]]
 then
-	mv -f ~/.tue ~/.tue.$(date +%F_%R)
+    FILES=$(find ~/.tue/user/envs -maxdepth 1 -type f)
+    for env in $FILES
+    do
+        mv -f $(cat $env) $(cat $env).$(date +%F_%R)
+    done
+    mv -f ~/.tue ~/.tue.$(date +%F_%R)
 fi
 
 # Update installer

--- a/installer/scripts/bootstrap-ros-kinetic
+++ b/installer/scripts/bootstrap-ros-kinetic
@@ -3,9 +3,15 @@
 # make sure git is installed
 hash git 2> /dev/null || sudo apt-get install --assume-yes git
 
+# Move old environments and installer
 if [[ -e ~/.tue && -z "$CI" ]]
 then
-	mv -f ~/.tue ~/.tue.$(date +%F_%R)
+    FILES=$(find ~/.tue/user/envs -maxdepth 1 -type f)
+    for env in $FILES
+    do
+        mv -f $(cat $env) $(cat $env).$(date +%F_%R)
+    done
+    mv -f ~/.tue ~/.tue.$(date +%F_%R)
 fi
 
 if [[ -z "$CI" ]]


### PR DESCRIPTION
Because tue-env init will stop when environment dir(ros/XX/.env) is already there. So bootstrap wasn't always succeeding when run for 2nd time.
The other option of changing the tue-env init function is incorrect in my opinion. That one should fail, if folders/files are already there.

The issue is that ~/.tue/user/envs/XX file is not always created. When this happens again, it is because of problems with creating/writing the file instead of not reaching that code.