### PR TITLE
fix(target)KDL parser uses kinetic devel branch

### DIFF
--- a/installer/targets/ros-kdl_parser/install.yaml
+++ b/installer/targets/ros-kdl_parser/install.yaml
@@ -2,4 +2,5 @@
   source:
     type: git
     url: https://github.com/ros/kdl_parser.git
+    version: kinetic-devel
     sub-dir: kdl_parser


### PR DESCRIPTION
N.B.: not yet tested on new installation