### PR TITLE
Exlude meta-packages from catkin test

### DIFF
--- a/ci/build-package.sh
+++ b/ci/build-package.sh
@@ -28,4 +28,4 @@ docker exec tue-env bash -c "export CI='true'; source /home/amigo/.bashrc; cd ~/
 
 # Check results of unit tests
 echo -e "\e[35m\e[1m Check results of unit test on this package (catkin_test_results build/$PACKAGE) \e[0m"
-docker exec tue-env bash -c "export CI='true'; source /home/amigo/.bashrc; cd ~/ros/kinetic/system/ && catkin_test_results build/$PACKAGE"
+docker exec tue-env bash -c "export CI='true'; source /home/amigo/.bashrc; cd ~/ros/kinetic/system/ && [ ! -d build/$PACKAGE ] || catkin_test_results build/$PACKAGE"


### PR DESCRIPTION
Exclude packages, whose folder does not exist, from catkin_test_results. This should only be the case for metapackages.