### PR TITLE
Add global gitignore

### DIFF
--- a/installer/targets/git/gitignore
+++ b/installer/targets/git/gitignore
@@ -1,0 +1,1 @@
+*CMakeLists.txt.user

--- a/installer/targets/git/install.bash
+++ b/installer/targets/git/install.bash
@@ -8,3 +8,5 @@ if [ ! -f /usr/local/bin/git-extras ]; then
 	# enable color
 	git config --global color.ui true
 fi
+
+git config --global --replace-all core.excludesFile $( dirname "${BASH_SOURCE[0]}")/gitignore


### PR DESCRIPTION
In my opinion this is best way to automate the configuration. This way it will be overwritten everytime the installer is runned, but I wasn't able to find easy check. 