### PR TITLE
removed quickssh alias

### DIFF
--- a/installer/targets/robot-user/setup
+++ b/installer/targets/robot-user/setup
@@ -83,9 +83,3 @@ function github-cache-credentials() {
 
 # Append '.local' to hostname for local resolving of hostnames
 export ROS_HOSTNAME=`hostname`.local
-
-# DECLARE ALIAS FOR QUICK SSH
-alias quickssh='echo "ControlMaster auto
-ControlPath /tmp/%r@%h:%p
-ControlPersist yes" > ~/.ssh/config'
-


### PR DESCRIPTION
This alias wasn't being used anywhere. Also, it was over writing the config file in .ssh