### PR TITLE
Fix/luarocks

### DIFF
--- a/installer/targets/openface/install.bash
+++ b/installer/targets/openface/install.bash
@@ -29,5 +29,4 @@ if [ ! -d ~/openface ]; then
         echo "openface is not properly installed"
     fi
 
-    luarocks install dpnn
 fi

--- a/installer/targets/openface/torch.bash
+++ b/installer/targets/openface/torch.bash
@@ -11,6 +11,8 @@ git clone https://github.com/torch/distro.git ~/torch --recursive
 cd ~/torch
 bash install-deps
 ./install.sh
+
+source ~/.bashrc
 source ~/.bashrc
 
 luarocks install dpnn

--- a/installer/targets/openface/torch.bash
+++ b/installer/targets/openface/torch.bash
@@ -12,6 +12,7 @@ cd ~/torch
 bash install-deps
 ./install.sh
 
+# One time sourcing doesn't work. Why? Unknown.
 source ~/.bashrc
 source ~/.bashrc
 


### PR DESCRIPTION
As mentioned in the file. One time sourcing doesn't work. Two times does. It is ugly and not able to test in travis, because it asks for confirmation of adding a path to the bashrc during installation. That happens before the sourcing of the bashrc.