### PR TITLE
Revert "Merge pull request #231 from tue-robotics/feature/diagnostic_…

### DIFF
--- a/installer/targets/ros-diagnostic_updater/install.yaml
+++ b/installer/targets/ros-diagnostic_updater/install.yaml
@@ -1,5 +1,4 @@
 - type: ros
   source:
-    type: git
-    url: https://github.com/tue-robotics/diagnostics.git
-    sub-dir: diagnostic_updater
+    type: system
+    name: diagnostic-updater


### PR DESCRIPTION
…updater_forked"

This reverts commit 0c0b5d898dc2e9ecdf2a60b9b36e6ce016fb4608, reversing
changes made to aa1e3a90b5cd7e3985f781170dc651e9c788dc45.

Because https://github.com/ros/diagnostics/pull/73 is merged. Package is also released.

Probably needs a full `catkin clean` to remove python files from `devel` folder after remove symlink in workspace.