### PR TITLE
Remove auto check for cuda in installer.

### DIFF
--- a/installer/tue-install-impl.bash
+++ b/installer/tue-install-impl.bash
@@ -744,11 +744,6 @@ TUE_INSTALL_SNAPS=
 TUE_INSTALL_WARNINGS=
 TUE_INSTALL_INFOS=
 
-if [ -d "/usr/local/cuda/" ]
-then
-    export TUE_CUDA=1
-fi
-
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 tue_cmd=$1


### PR DESCRIPTION
 Let it be decided by the user self. So the user can set TUE_CUDA to use cuda in targets or not.

@LarsJanssenTUe This will prevent the issue tensorflow issue to happen again by running `tue-get update`