### PR TITLE
fix tue-status

### DIFF
--- a/setup/tue-functions.bash
+++ b/setup/tue-functions.bash
@@ -224,7 +224,7 @@ function _tue-repo-status
     local status=
     local vctype=
 
-    if [ -d "$pkg_dir"/.git ]
+    if git -C "$pkg_dir" rev-parse --git-dir > /dev/null 2>&1
     then
         # Try git
 


### PR DESCRIPTION
It was broken, because pkd_dir could also be a subfolder of a git repo. So `.git` would never be found.