### PR TITLE
Check and display all removed targets first

### DIFF
--- a/installer/tue-install-impl.bash
+++ b/installer/tue-install-impl.bash
@@ -755,7 +755,7 @@ function _missing_targets_check
     if [ -n "$missing_targets" ]
     then
         missing_targets=$(echo "$missing_targets" | tr " " "\n" | sort)
-        echo -e "\e[31m Error! The following installed targets do not exist (anymore):\n$missing_targets \e[0m"
+        echo -e "\e[31mThe following installed targets don't exist (anymore):\n$missing_targets \e[0m"
         exit 1
     fi
 

--- a/installer/tue-install-impl.bash
+++ b/installer/tue-install-impl.bash
@@ -736,6 +736,33 @@ function generate_setup_file
 }
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+function _missing_targets_check
+{
+    # Check if valid target received as input
+    local targets="$1"
+    local missing_targets=""
+    local target
+
+    for target in $targets
+    do
+        if [ ! -d "$TUE_INSTALL_TARGETS_DIR"/"$target" ]
+        then
+            missing_targets="$target${missing_targets:+ ${missing_targets}}"
+        fi
+    done
+
+    if [ -n "$missing_targets" ]
+    then
+        missing_targets=$(echo "$missing_targets" | tr " " "\n" | sort)
+        echo -e "\e[31m Error! The following installed targets do not exist (anymore):\n$missing_targets \e[0m"
+        exit 1
+    fi
+
+    return 0
+}
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 #                                           MAIN LOOP
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
@@ -794,6 +821,9 @@ then
     # If no targets are provided, update all installed targets
     targets=$(ls "$TUE_INSTALL_INSTALLED_DIR")
 fi
+
+# Check if all installed targets exist in the targets repo
+_missing_targets_check "$targets"
 
 for target in $targets
 do

--- a/installer/tue-install-impl.bash
+++ b/installer/tue-install-impl.bash
@@ -828,6 +828,7 @@ _missing_targets_check "$targets"
 for target in $targets
 do
     tue-install-debug "Main loop: installing $target"
+    # Next line shouldn't error anymore with _missing_targets_check
     tue-install-target "$target" || tue-install-error "Installed target: '$target' doesn't exist (anymore)"
 
     if [[ "$tue_cmd" == "install" ]]


### PR DESCRIPTION
Lets say we have 100 targets are installed and 5 of them are not in targets repo anymore.

Currently there is no order in which their existence is checked. 

It may so happen that the first missing target is found after updating 20 targets and the installation will break. After fixing this missing target, the installer will again go through all the 20 targets and so on, which is a waste of time. 

This PR fixes this issue.
Fixes #403 