### PR TITLE
Change CI for multi-package repo

### DIFF
--- a/ci/.travis.yml.multiple_pkgs.example
+++ b/ci/.travis.yml.multiple_pkgs.example
@@ -12,9 +12,13 @@ before_install:
   # Determine packages modified in this commit
   - source packages.sh # add all folders which need to be excluded as an argument
 
+env:
+  - PACKAGE=package1
+  - PACKAGE=package2
+  - PACKAGE=package3
+
+install:
+  - bash install-package.sh --package=$PACKAGE --branch=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} --commit=$TRAVIS_COMMIT --pullrequest=$TRAVIS_PULL_REQUEST
+
 script:
-  - 'for PACKAGE in $PACKAGES;
-     do
-     bash install-package.sh --package=$PACKAGE --branch=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} --commit=$TRAVIS_COMMIT --pullrequest=$TRAVIS_PULL_REQUEST &&
-     bash build-package.sh --package=$PACKAGE;
-     done'
+  - bash build-package.sh --package=$PACKAGE

--- a/ci/build-package.sh
+++ b/ci/build-package.sh
@@ -30,6 +30,15 @@ done
 
 echo -e "\e[35m\e[1m PACKAGE     = ${PACKAGE} \e[0m"
 
+# If packages is non-zero, this is a multi-package repo. In multi-package repo, check if this package needs CI.
+# If a single-package repo, CI is always needed.
+# shellcheck disable=SC2153
+if [ -n "$PACKAGES" ] && ! echo "$PACKAGES" | grep -sqw "$PACKAGE"
+then
+    echo -e "\e[35m\e[1m No changes in this package, so no need to run CI \e[0m"
+    return 0
+fi
+
 # Use docker environment variables in all exec commands instead of script variables
 # Compile the package
 echo -e "\e[35m\e[1m Compile the package (catkin build -DCATKIN_ENABLE_TESTING=OFF) \e[0m"

--- a/ci/build-package.sh
+++ b/ci/build-package.sh
@@ -30,6 +30,8 @@ done
 
 echo -e "\e[35m\e[1m PACKAGE     = ${PACKAGE} \e[0m"
 
+echo -e "\e[35m\e[1m PACKAGES     = ${PACKAGES} \e[0m"
+
 # If packages is non-zero, this is a multi-package repo. In multi-package repo, check if this package needs CI.
 # If a single-package repo, CI is always needed.
 # shellcheck disable=SC2153

--- a/ci/build-package.sh
+++ b/ci/build-package.sh
@@ -38,7 +38,7 @@ echo -e "\e[35m\e[1m PACKAGES     = ${PACKAGES} \e[0m"
 if [ -n "$PACKAGES" ] && ! echo "$PACKAGES" | grep -sqw "$PACKAGE"
 then
     echo -e "\e[35m\e[1m No changes in this package, so no need to run CI \e[0m"
-    return 0
+    exit 0
 fi
 
 # Use docker environment variables in all exec commands instead of script variables

--- a/ci/build-package.sh
+++ b/ci/build-package.sh
@@ -30,8 +30,6 @@ done
 
 echo -e "\e[35m\e[1m PACKAGE     = ${PACKAGE} \e[0m"
 
-echo -e "\e[35m\e[1m PACKAGES     = ${PACKAGES} \e[0m"
-
 # If packages is non-zero, this is a multi-package repo. In multi-package repo, check if this package needs CI.
 # If a single-package repo, CI is always needed.
 # shellcheck disable=SC2153

--- a/ci/install-package.sh
+++ b/ci/install-package.sh
@@ -52,8 +52,6 @@ tue-get install docker
 Optionally fix your compilation errors and re-run only the last command
 \e[0m"
 
-echo -e "\e[35m\e[1m PACKAGES     = ${PACKAGES} \e[0m"
-
 # If packages is non-zero, this is a multi-package repo. In multi-package repo, check if this package needs CI.
 # If a single-package repo, CI is always needed.
 # shellcheck disable=SC2153

--- a/ci/install-package.sh
+++ b/ci/install-package.sh
@@ -60,7 +60,7 @@ echo -e "\e[35m\e[1m PACKAGES     = ${PACKAGES} \e[0m"
 if [ -n "$PACKAGES" ] && ! echo "$PACKAGES" | grep -sqw "$PACKAGE"
 then
     echo -e "\e[35m\e[1m No changes in this package, so no need to run CI \e[0m"
-    return 0
+    exit 0
 fi
 
 # Name of the docker image

--- a/ci/install-package.sh
+++ b/ci/install-package.sh
@@ -52,6 +52,15 @@ tue-get install docker
 Optionally fix your compilation errors and re-run only the last command
 \e[0m"
 
+# If packages is non-zero, this is a multi-package repo. In multi-package repo, check if this package needs CI.
+# If a single-package repo, CI is always needed.
+# shellcheck disable=SC2153
+if [ -n "$PACKAGES" ] && ! echo "$PACKAGES" | grep -sqw "$PACKAGE"
+then
+    echo -e "\e[35m\e[1m No changes in this package, so no need to run CI \e[0m"
+    return 0
+fi
+
 # Name of the docker image
 IMAGE_NAME=tuerobotics/tue-env
 # Determine docker tag if the same branch exists there

--- a/ci/install-package.sh
+++ b/ci/install-package.sh
@@ -52,6 +52,8 @@ tue-get install docker
 Optionally fix your compilation errors and re-run only the last command
 \e[0m"
 
+echo -e "\e[35m\e[1m PACKAGES     = ${PACKAGES} \e[0m"
+
 # If packages is non-zero, this is a multi-package repo. In multi-package repo, check if this package needs CI.
 # If a single-package repo, CI is always needed.
 # shellcheck disable=SC2153


### PR DESCRIPTION
Travis runs easily into a time limit when running on a multi-package repo. Therefore the result is actually useless as not all package can be tested.
Another flaw is that success is only determined on the success of the last package. See https://travis-ci.com/tue-robotics/navigation/builds/122691895, `amcl` fails on `map_server` (and many more errors), but because `voxel_grid` succeedes, the whole CI succeedes. This is completely incorrect. 

My proposed setup, runs all the packages in parallel by using the matrix functionality of travis. This prevents running into a timeout, because of running packages serial. (Single packages could still run in a timeout). Also the problem of a incorrect success status is fixed. Packages which haven't changed will not be installed and build. Those packages will succeed in a very short time. (Showing these as ignored isn't possible.)

In the new setup, the travis config needs to be adjusted for each repo. (Travis doesn't allow the matrix to configured on runtime.) All packages need to be added to the list of environment variables. Though this needs to be only done once.

The result of the new CI can be seen here, tested on navigation: https://travis-ci.com/tue-robotics/navigation/builds/122705133

Skipping a package, costmap_2d, is shown here: https://travis-ci.com/tue-robotics/navigation/jobs/224172024
(It was manually skipped by adding it as an argument to `packages.sh`

If have also tested the new scripts on a single package repo, ED. It still works: https://travis-ci.com/tue-robotics/ed/builds/122706565