### PR TITLE
build RelWithDebInfo

### DIFF
--- a/setup/tue-functions.bash
+++ b/setup/tue-functions.bash
@@ -230,11 +230,11 @@ function tue-make
             catkin_make --directory "$_TUE_CATKIN_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
             ;;
         'catkin build')
-            catkin build --workspace "$_TUE_CATKIN_SYSTEM_DIR" "$@"
+            catkin build --workspace "$_TUE_CATKIN_SYSTEM_DIR" --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
             ;;
         '')
             catkin init --workspace "$_TUE_CATKIN_SYSTEM_DIR" "$@"
-            catkin build --workspace "$_TUE_CATKIN_SYSTEM_DIR" "$@"
+            catkin build --workspace "$_TUE_CATKIN_SYSTEM_DIR" --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
             ;;
         esac
     fi


### PR DESCRIPTION
I checked `htop`, first ED was using around 38% CPU, after building with RelWithDebInfo, it only uses around 30% CPU