### PR TITLE
Fix release build

### DIFF
--- a/ci/build-package.sh
+++ b/ci/build-package.sh
@@ -42,12 +42,12 @@ fi
 # Use docker environment variables in all exec commands instead of script variables
 # Compile the package
 echo -e "\e[35m\e[1m Compile the package (catkin build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCATKIN_ENABLE_TESTING=OFF) \e[0m"
-docker exec tue-env bash -c 'source ~/.bashrc; cd ~/ros/"$ROS_DISTRO"/system/src/"$PACKAGE" && catkin build --this --no-status -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCATKIN_ENABLE_TESTING=OFF'
+docker exec tue-env bash -c 'source ~/.bashrc; cd "$TUE_SYSTEM_DIR"/src/"$PACKAGE" && catkin build --this --no-status -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCATKIN_ENABLE_TESTING=OFF'
 
 # Run unit tests
 echo -e "\e[35m\e[1m Run tests on this package (catkin run_tests --this --no-deps -DCATKIN_ENABLE_TESTING=ON) \e[0m"
-docker exec tue-env bash -c 'source ~/.bashrc; cd ~/ros/"$ROS_DISTRO"/system/src/"$PACKAGE" && catkin run_tests --this --no-status --no-deps -DCATKIN_ENABLE_TESTING=ON'
+docker exec tue-env bash -c 'source ~/.bashrc; cd "$TUE_SYSTEM_DIR"/src/"$PACKAGE" && catkin run_tests --this --no-status --no-deps -DCATKIN_ENABLE_TESTING=ON'
 
 # Check results of unit tests
 echo -e "\e[35m\e[1m Check results of the tests on this package (catkin_test_results build/$PACKAGE) \e[0m"
-docker exec tue-env bash -c 'source ~/.bashrc; cd ~/ros/"$ROS_DISTRO"/system/ && [ ! -d build/"$PACKAGE" ] || catkin_test_results build/"$PACKAGE"'
+docker exec tue-env bash -c 'source ~/.bashrc; cd "$TUE_SYSTEM_DIR" && [ ! -d build/"$PACKAGE" ] || catkin_test_results build/"$PACKAGE"'

--- a/ci/build-package.sh
+++ b/ci/build-package.sh
@@ -41,8 +41,8 @@ fi
 
 # Use docker environment variables in all exec commands instead of script variables
 # Compile the package
-echo -e "\e[35m\e[1m Compile the package (catkin build -DCATKIN_ENABLE_TESTING=OFF) \e[0m"
-docker exec tue-env bash -c 'source ~/.bashrc; cd ~/ros/"$ROS_DISTRO"/system/src/"$PACKAGE" && catkin build --this --no-status -DCATKIN_ENABLE_TESTING=OFF'
+echo -e "\e[35m\e[1m Compile the package (catkin build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCATKIN_ENABLE_TESTING=OFF) \e[0m"
+docker exec tue-env bash -c 'source ~/.bashrc; cd ~/ros/"$ROS_DISTRO"/system/src/"$PACKAGE" && catkin build --this --no-status -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCATKIN_ENABLE_TESTING=OFF'
 
 # Run unit tests
 echo -e "\e[35m\e[1m Run tests on this package (catkin run_tests --this --no-deps -DCATKIN_ENABLE_TESTING=ON) \e[0m"

--- a/installer/tue-install-impl.bash
+++ b/installer/tue-install-impl.bash
@@ -10,7 +10,6 @@ mkdir -p "$TUE_INSTALL_INSTALLED_DIR"
 
 TUE_INSTALL_TARGETS_DIR=$TUE_ENV_TARGETS_DIR
 
-TUE_SYSTEM_DIR=$TUE_ENV_DIR/system
 TUE_REPOS_DIR=$TUE_ENV_DIR/repos
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #

--- a/setup/tue-functions.bash
+++ b/setup/tue-functions.bash
@@ -1,5 +1,6 @@
 #! /usr/bin/env bash
 
+# shellcheck disable=SC2153
 TUE_DEV_DIR=$TUE_ENV_DIR/dev
 TUE_SYSTEM_DIR=$TUE_ENV_DIR/system
 

--- a/setup/tue-functions.bash
+++ b/setup/tue-functions.bash
@@ -227,7 +227,7 @@ function tue-make
     then
         case $(cat "$TUE_SYSTEM_DIR"/devel/.built_by) in
         'catkin_make')
-            catkin_make --directory "$TUE_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+            echo -e "\e[33mcatkin_make is not supported anymore, use catkin tools\e[0m"
             ;;
         'catkin build')
             catkin build --workspace "$TUE_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
@@ -244,7 +244,7 @@ function tue-make-system
 {
     case $(cat "$TUE_SYSTEM_DIR"/devel/.built_by) in
     'catkin_make')
-        catkin_make --directory "$TUE_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+        echo -e "\e[33mcatkin_make is not supported anymore, use catkin tools\e[0m"
         ;;
     'catkin build')
         catkin build --workspace "$TUE_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
@@ -270,7 +270,7 @@ function tue-make-dev
 {
     case $(cat "$TUE_DEV_DIR"/devel/.built_by) in
     'catkin_make')
-        catkin_make --directory "$TUE_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+        echo -e "\e[33mcatkin_make is not supported anymore, use catkin tools\e[0m"
         ;;
     'catkin build')
         catkin build --workspace "$TUE_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
@@ -286,7 +286,7 @@ function tue-make-dev-isolated
 {
     case $(cat "$TUE_DEV_DIR"/devel/.built_by) in
     'catkin_make')
-        catkin_make_isolated --directory "$TUE_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+        echo -e "\e[33mcatkin_make is not supported anymore, use catkin tools\e[0m"
         ;;
     'catkin build')
         catkin build --workspace "$TUE_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"

--- a/setup/tue-functions.bash
+++ b/setup/tue-functions.bash
@@ -253,18 +253,21 @@ complete -F _tue-make tue-make
 
 function tue-make-dev
 {
-    case $(cat "$TUE_DEV_DIR"/devel/.built_by) in
-    'catkin_make')
-        echo -e "\e[33mcatkin_make is not supported anymore, use catkin tools\e[0m"
-        ;;
-    'catkin build')
-        catkin build --workspace "$TUE_DEV_DIR" "$@"
-        ;;
-    '')
-        catkin config --init --mkdirs --workspace "$TUE_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
-        catkin build --workspace "$TUE_DEV_DIR" "$@"
-        ;;
-    esac
+	if [ -n "$TUE_ROS_DISTRO" ] && [ -d "$TUE_DEV_DIR" ]
+    then
+		case $(cat "$TUE_DEV_DIR"/devel/.built_by) in
+		'catkin_make')
+			echo -e "\e[33mcatkin_make is not supported anymore, use catkin tools\e[0m"
+			;;
+		'catkin build')
+			catkin build --workspace "$TUE_DEV_DIR" "$@"
+			;;
+		'')
+			catkin config --init --mkdirs --workspace "$TUE_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+			catkin build --workspace "$TUE_DEV_DIR" "$@"
+			;;
+		esac
+    fi
 }
 export -f tue-make-dev
 

--- a/setup/tue-functions.bash
+++ b/setup/tue-functions.bash
@@ -242,23 +242,6 @@ function tue-make
 }
 export -f tue-make
 
-function tue-make-system
-{
-    case $(cat "$TUE_SYSTEM_DIR"/devel/.built_by) in
-    'catkin_make')
-        echo -e "\e[33mcatkin_make is not supported anymore, use catkin tools\e[0m"
-        ;;
-    'catkin build')
-        catkin build --workspace "$TUE_SYSTEM_DIR" "$@"
-        ;;
-    '')
-        catkin config --init --mkdirs --workspace "$TUE_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
-        catkin build --workspace "$TUE_SYSTEM_DIR" "$@"
-        ;;
-    esac
-}
-export -f tue-make-system
-
 function _tue-make
 {
     local cur=${COMP_WORDS[COMP_CWORD]}
@@ -267,7 +250,6 @@ function _tue-make
 }
 
 complete -F _tue-make tue-make
-complete -F _tue-make tue-make-system
 
 function tue-make-dev
 {
@@ -286,23 +268,6 @@ function tue-make-dev
 }
 export -f tue-make-dev
 
-function tue-make-dev-isolated
-{
-    case $(cat "$TUE_DEV_DIR"/devel/.built_by) in
-    'catkin_make')
-        echo -e "\e[33mcatkin_make is not supported anymore, use catkin tools\e[0m"
-        ;;
-    'catkin build')
-        catkin build --workspace "$TUE_DEV_DIR" "$@"
-        ;;
-    '')
-        catkin config --init --mkdirs --workspace "$TUE_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
-        catkin build --workspace "$TUE_DEV_DIR" "$@"
-        ;;
-    esac
-}
-export -f tue-make-dev-isolated
-
 function _tue-make-dev
 {
     local cur=${COMP_WORDS[COMP_CWORD]}
@@ -310,7 +275,6 @@ function _tue-make-dev
     mapfile -t COMPREPLY < <(compgen -W "$(_list_subdirs "$TUE_DEV_DIR"/src)" -- "$cur")
 }
 complete -F _tue-make-dev tue-make-dev
-complete -F _tue-make-dev tue-make-dev-isolated
 
 # ----------------------------------------------------------------------------------------------------
 #                                              TUE-DEV

--- a/setup/tue-functions.bash
+++ b/setup/tue-functions.bash
@@ -3,6 +3,8 @@
 # shellcheck disable=SC2153
 TUE_DEV_DIR=$TUE_ENV_DIR/dev
 TUE_SYSTEM_DIR=$TUE_ENV_DIR/system
+export TUE_DEV_DIR
+export TUE_SYSTEM_DIR
 
 # ----------------------------------------------------------------------------------------------------
 #                                        HELPER FUNCTIONS

--- a/setup/tue-functions.bash
+++ b/setup/tue-functions.bash
@@ -230,11 +230,11 @@ function tue-make
             catkin_make --directory "$_TUE_CATKIN_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
             ;;
         'catkin build')
-            catkin build --workspace "$_TUE_CATKIN_SYSTEM_DIR" --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+            catkin build --workspace "$_TUE_CATKIN_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
             ;;
         '')
             catkin init --workspace "$_TUE_CATKIN_SYSTEM_DIR" "$@"
-            catkin build --workspace "$_TUE_CATKIN_SYSTEM_DIR" --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+            catkin build --workspace "$_TUE_CATKIN_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
             ;;
         esac
     fi
@@ -247,11 +247,11 @@ function tue-make-system
         catkin_make --directory "$_TUE_CATKIN_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
         ;;
     'catkin build')
-        catkin build --workspace "$_TUE_CATKIN_SYSTEM_DIR" "$@"
+        catkin build --workspace "$_TUE_CATKIN_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
         ;;
     '')
         catkin init --workspace "$_TUE_CATKIN_SYSTEM_DIR" "$@"
-        catkin build --workspace "$_TUE_CATKIN_SYSTEM_DIR" "$@"
+        catkin build --workspace "$_TUE_CATKIN_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
         ;;
     esac
 }
@@ -273,11 +273,11 @@ function tue-make-dev
         catkin_make --directory "$_TUE_CATKIN_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
         ;;
     'catkin build')
-        catkin build --workspace "$_TUE_CATKIN_DEV_DIR" "$@"
+        catkin build --workspace "$_TUE_CATKIN_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
         ;;
     '')
         catkin init --workspace "$_TUE_CATKIN_DEV_DIR" "$@"
-        catkin build --workspace "$_TUE_CATKIN_DEV_DIR" "$@"
+        catkin build --workspace "$_TUE_CATKIN_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
         ;;
     esac
 }
@@ -289,11 +289,11 @@ function tue-make-dev-isolated
         catkin_make_isolated --directory "$_TUE_CATKIN_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
         ;;
     'catkin build')
-        catkin build --workspace "$_TUE_CATKIN_DEV_DIR" "$@"
+        catkin build --workspace "$_TUE_CATKIN_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
         ;;
     '')
         catkin init --workspace "$_TUE_CATKIN_DEV_DIR" "$@"
-        catkin build --workspace "$_TUE_CATKIN_DEV_DIR" "$@"
+        catkin build --workspace "$_TUE_CATKIN_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
         ;;
     esac
 }

--- a/setup/tue-functions.bash
+++ b/setup/tue-functions.bash
@@ -230,11 +230,11 @@ function tue-make
             echo -e "\e[33mcatkin_make is not supported anymore, use catkin tools\e[0m"
             ;;
         'catkin build')
-            catkin build --workspace "$TUE_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+            catkin build --workspace "$TUE_SYSTEM_DIR" "$@"
             ;;
         '')
-            catkin config --init --mkdirs --workspace "$TUE_SYSTEM_DIR" "$@"
-            catkin build --workspace "$TUE_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+            catkin config --init --mkdirs --workspace "$TUE_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+            catkin build --workspace "$TUE_SYSTEM_DIR" "$@"
             ;;
         esac
     fi
@@ -247,11 +247,11 @@ function tue-make-system
         echo -e "\e[33mcatkin_make is not supported anymore, use catkin tools\e[0m"
         ;;
     'catkin build')
-        catkin build --workspace "$TUE_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+        catkin build --workspace "$TUE_SYSTEM_DIR" "$@"
         ;;
     '')
-        catkin config --init --mkdirs --workspace "$TUE_SYSTEM_DIR" "$@"
-        catkin build --workspace "$TUE_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+        catkin config --init --mkdirs --workspace "$TUE_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+        catkin build --workspace "$TUE_SYSTEM_DIR" "$@"
         ;;
     esac
 }
@@ -273,11 +273,11 @@ function tue-make-dev
         echo -e "\e[33mcatkin_make is not supported anymore, use catkin tools\e[0m"
         ;;
     'catkin build')
-        catkin build --workspace "$TUE_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+        catkin build --workspace "$TUE_DEV_DIR" "$@"
         ;;
     '')
-        catkin config --init --mkdirs --workspace "$TUE_DEV_DIR" "$@"
-        catkin build --workspace "$TUE_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+        catkin config --init --mkdirs --workspace "$TUE_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+        catkin build --workspace "$TUE_DEV_DIR" "$@"
         ;;
     esac
 }
@@ -289,11 +289,11 @@ function tue-make-dev-isolated
         echo -e "\e[33mcatkin_make is not supported anymore, use catkin tools\e[0m"
         ;;
     'catkin build')
-        catkin build --workspace "$TUE_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+        catkin build --workspace "$TUE_DEV_DIR" "$@"
         ;;
     '')
-        catkin config --init --mkdirs --workspace "$TUE_DEV_DIR" "$@"
-        catkin build --workspace "$TUE_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+        catkin config --init --mkdirs --workspace "$TUE_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+        catkin build --workspace "$TUE_DEV_DIR" "$@"
         ;;
     esac
 }

--- a/setup/tue-functions.bash
+++ b/setup/tue-functions.bash
@@ -240,6 +240,7 @@ function tue-make
         esac
     fi
 }
+export -f tue-make
 
 function tue-make-system
 {
@@ -256,6 +257,7 @@ function tue-make-system
         ;;
     esac
 }
+export -f tue-make-system
 
 function _tue-make
 {
@@ -282,6 +284,7 @@ function tue-make-dev
         ;;
     esac
 }
+export -f tue-make-dev
 
 function tue-make-dev-isolated
 {
@@ -298,6 +301,7 @@ function tue-make-dev-isolated
         ;;
     esac
 }
+export -f tue-make-dev-isolated
 
 function _tue-make-dev
 {

--- a/setup/tue-functions.bash
+++ b/setup/tue-functions.bash
@@ -228,16 +228,19 @@ function tue-make
 {
     if [ -n "$TUE_ROS_DISTRO" ] && [ -d "$TUE_SYSTEM_DIR" ]
     then
-        case $(cat "$TUE_SYSTEM_DIR"/devel/.built_by) in
-        'catkin_make')
-            echo -e "\e[33mcatkin_make is not supported anymore, use catkin tools\e[0m"
-            ;;
+        local build_tool
+        build_tool=$(cat "$TUE_SYSTEM_DIR"/devel/.built_by)
+        case $build_tool in
         'catkin build')
             catkin build --workspace "$TUE_SYSTEM_DIR" "$@"
             ;;
         '')
             catkin config --init --mkdirs --workspace "$TUE_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
             catkin build --workspace "$TUE_SYSTEM_DIR" "$@"
+            ;;
+        *)
+            echo -e "\e$build_tool is not supported (anymore), use catkin tools\e[0m"
+            return 1
             ;;
         esac
     fi
@@ -255,20 +258,23 @@ complete -F _tue-make tue-make
 
 function tue-make-dev
 {
-	if [ -n "$TUE_ROS_DISTRO" ] && [ -d "$TUE_DEV_DIR" ]
+    if [ -n "$TUE_ROS_DISTRO" ] && [ -d "$TUE_DEV_DIR" ]
     then
-		case $(cat "$TUE_DEV_DIR"/devel/.built_by) in
-		'catkin_make')
-			echo -e "\e[33mcatkin_make is not supported anymore, use catkin tools\e[0m"
-			;;
-		'catkin build')
-			catkin build --workspace "$TUE_DEV_DIR" "$@"
-			;;
-		'')
-			catkin config --init --mkdirs --workspace "$TUE_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
-			catkin build --workspace "$TUE_DEV_DIR" "$@"
-			;;
-		esac
+        local build_tool
+        build_tool=$(cat "$TUE_DEV_DIR"/devel/.built_by)
+        case $build_tool in
+        'catkin build')
+            catkin build --workspace "$TUE_DEV_DIR" "$@"
+            ;;
+        '')
+            catkin config --init --mkdirs --workspace "$TUE_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+            catkin build --workspace "$TUE_DEV_DIR" "$@"
+            ;;
+        *)
+            echo -e "\e$build_tool is not supported (anymore), use catkin tools\e[0m"
+            return 1
+            ;;
+        esac
     fi
 }
 export -f tue-make-dev

--- a/setup/tue-functions.bash
+++ b/setup/tue-functions.bash
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
-_TUE_CATKIN_DEV_DIR=$TUE_ENV_DIR/dev
-_TUE_CATKIN_SYSTEM_DIR=$TUE_ENV_DIR/system
+TUE_DEV_DIR=$TUE_ENV_DIR/dev
+TUE_SYSTEM_DIR=$TUE_ENV_DIR/system
 
 # ----------------------------------------------------------------------------------------------------
 #                                        HELPER FUNCTIONS
@@ -223,18 +223,18 @@ export -f _github_https_or_ssh # otherwise not available in sourced files
 
 function tue-make
 {
-    if [ -n "$TUE_ROS_DISTRO" ] && [ -d "$_TUE_CATKIN_SYSTEM_DIR" ]
+    if [ -n "$TUE_ROS_DISTRO" ] && [ -d "$TUE_SYSTEM_DIR" ]
     then
-        case $(cat "$_TUE_CATKIN_SYSTEM_DIR"/devel/.built_by) in
+        case $(cat "$TUE_SYSTEM_DIR"/devel/.built_by) in
         'catkin_make')
-            catkin_make --directory "$_TUE_CATKIN_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+            catkin_make --directory "$TUE_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
             ;;
         'catkin build')
-            catkin build --workspace "$_TUE_CATKIN_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+            catkin build --workspace "$TUE_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
             ;;
         '')
-            catkin init --workspace "$_TUE_CATKIN_SYSTEM_DIR" "$@"
-            catkin build --workspace "$_TUE_CATKIN_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+            catkin init --workspace "$TUE_SYSTEM_DIR" "$@"
+            catkin build --workspace "$TUE_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
             ;;
         esac
     fi
@@ -242,16 +242,16 @@ function tue-make
 
 function tue-make-system
 {
-    case $(cat "$_TUE_CATKIN_SYSTEM_DIR"/devel/.built_by) in
+    case $(cat "$TUE_SYSTEM_DIR"/devel/.built_by) in
     'catkin_make')
-        catkin_make --directory "$_TUE_CATKIN_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+        catkin_make --directory "$TUE_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
         ;;
     'catkin build')
-        catkin build --workspace "$_TUE_CATKIN_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+        catkin build --workspace "$TUE_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
         ;;
     '')
-        catkin init --workspace "$_TUE_CATKIN_SYSTEM_DIR" "$@"
-        catkin build --workspace "$_TUE_CATKIN_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+        catkin init --workspace "$TUE_SYSTEM_DIR" "$@"
+        catkin build --workspace "$TUE_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
         ;;
     esac
 }
@@ -260,7 +260,7 @@ function _tue-make
 {
     local cur=${COMP_WORDS[COMP_CWORD]}
 
-    mapfile -t COMPREPLY < <(compgen -W "$(_list_subdirs "$_TUE_CATKIN_SYSTEM_DIR"/src)" -- "$cur")
+    mapfile -t COMPREPLY < <(compgen -W "$(_list_subdirs "$TUE_SYSTEM_DIR"/src)" -- "$cur")
 }
 
 complete -F _tue-make tue-make
@@ -268,32 +268,32 @@ complete -F _tue-make tue-make-system
 
 function tue-make-dev
 {
-    case $(cat "$_TUE_CATKIN_DEV_DIR"/devel/.built_by) in
+    case $(cat "$TUE_DEV_DIR"/devel/.built_by) in
     'catkin_make')
-        catkin_make --directory "$_TUE_CATKIN_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+        catkin_make --directory "$TUE_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
         ;;
     'catkin build')
-        catkin build --workspace "$_TUE_CATKIN_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+        catkin build --workspace "$TUE_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
         ;;
     '')
-        catkin init --workspace "$_TUE_CATKIN_DEV_DIR" "$@"
-        catkin build --workspace "$_TUE_CATKIN_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+        catkin init --workspace "$TUE_DEV_DIR" "$@"
+        catkin build --workspace "$TUE_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
         ;;
     esac
 }
 
 function tue-make-dev-isolated
 {
-    case $(cat "$_TUE_CATKIN_SYSTEM_DIR"/devel/.built_by) in
+    case $(cat "$TUE_DEV_DIR"/devel/.built_by) in
     'catkin_make')
-        catkin_make_isolated --directory "$_TUE_CATKIN_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+        catkin_make_isolated --directory "$TUE_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
         ;;
     'catkin build')
-        catkin build --workspace "$_TUE_CATKIN_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+        catkin build --workspace "$TUE_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
         ;;
     '')
-        catkin init --workspace "$_TUE_CATKIN_DEV_DIR" "$@"
-        catkin build --workspace "$_TUE_CATKIN_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
+        catkin init --workspace "$TUE_DEV_DIR" "$@"
+        catkin build --workspace "$TUE_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
         ;;
     esac
 }
@@ -302,7 +302,7 @@ function _tue-make-dev
 {
     local cur=${COMP_WORDS[COMP_CWORD]}
 
-    mapfile -t COMPREPLY < <(compgen -W "$(_list_subdirs "$_TUE_CATKIN_DEV_DIR"/src)" -- "$cur")
+    mapfile -t COMPREPLY < <(compgen -W "$(_list_subdirs "$TUE_DEV_DIR"/src)" -- "$cur")
 }
 complete -F _tue-make-dev tue-make-dev
 complete -F _tue-make-dev tue-make-dev-isolated
@@ -315,20 +315,20 @@ function tue-dev
 {
     if [ -z "$1" ]
     then
-        _list_subdirs "$_TUE_CATKIN_DEV_DIR"/src
+        _list_subdirs "$TUE_DEV_DIR"/src
         return 0
     fi
 
     for pkg in "$@"
     do
-        if [ ! -d "$_TUE_CATKIN_SYSTEM_DIR"/src/"$pkg" ]
+        if [ ! -d "$TUE_SYSTEM_DIR"/src/"$pkg" ]
         then
             echo "[tue-dev] '$pkg' does not exist in the system workspace."
-        elif [ -d "$_TUE_CATKIN_DEV_DIR"/src/"$pkg" ]
+        elif [ -d "$TUE_DEV_DIR"/src/"$pkg" ]
         then
             echo "[tue-dev] '$pkg' is already in the dev workspace."
         else
-            ln -s "$_TUE_CATKIN_SYSTEM_DIR"/src/"$pkg" "$_TUE_CATKIN_DEV_DIR"/src/"$pkg"
+            ln -s "$TUE_SYSTEM_DIR"/src/"$pkg" "$TUE_DEV_DIR"/src/"$pkg"
         fi
     done
 
@@ -338,28 +338,28 @@ function tue-dev
 
 function tue-dev-clean
 {
-    for f in $(_list_subdirs "$_TUE_CATKIN_DEV_DIR"/src)
+    for f in $(_list_subdirs "$TUE_DEV_DIR"/src)
     do
         # Test if f is a symbolic link
-        if [[ -L $_TUE_CATKIN_DEV_DIR/src/$f ]]
+        if [[ -L $TUE_DEV_DIR/src/$f ]]
         then
             echo "Cleaned '$f'"
-            rm "$_TUE_CATKIN_DEV_DIR"/src/"$f"
+            rm "$TUE_DEV_DIR"/src/"$f"
         fi
     done
 
-    rm -rf "$_TUE_CATKIN_DEV_DIR"/devel/share
-    rm -rf "$_TUE_CATKIN_DEV_DIR"/devel/etc
-    rm -rf "$_TUE_CATKIN_DEV_DIR"/devel/include
-    rm -rf "$_TUE_CATKIN_DEV_DIR"/devel/lib
-    rm -rf "$_TUE_CATKIN_DEV_DIR"/build
+    rm -rf "$TUE_DEV_DIR"/devel/share
+    rm -rf "$TUE_DEV_DIR"/devel/etc
+    rm -rf "$TUE_DEV_DIR"/devel/include
+    rm -rf "$TUE_DEV_DIR"/devel/lib
+    rm -rf "$TUE_DEV_DIR"/build
 }
 
 function _tue-dev
 {
     local cur=${COMP_WORDS[COMP_CWORD]}
 
-    mapfile -t COMPREPLY < <(compgen -W "$(_list_subdirs "$_TUE_CATKIN_SYSTEM_DIR"/src)" -- "$cur")
+    mapfile -t COMPREPLY < <(compgen -W "$(_list_subdirs "$TUE_SYSTEM_DIR"/src)" -- "$cur")
 }
 complete -F _tue-dev tue-dev
 
@@ -455,7 +455,7 @@ function _tue-dir-status
 
 function tue-status
 {
-    _tue-dir-status "$_TUE_CATKIN_SYSTEM_DIR"/src
+    _tue-dir-status "$TUE_SYSTEM_DIR"/src
     _tue-repo-status "tue-env" "$TUE_DIR"
     _tue-repo-status "tue-env-targets" "$TUE_ENV_TARGETS_DIR"
 }
@@ -464,7 +464,7 @@ function tue-status
 
 function tue-git-status
 {
-    for pkg_dir in "$_TUE_CATKIN_SYSTEM_DIR"/src/*/
+    for pkg_dir in "$TUE_SYSTEM_DIR"/src/*/
     do
         pkg=$(basename "$pkg_dir")
 
@@ -484,7 +484,7 @@ function tue-revert
 {
     human_time="$*"
 
-    for pkg_dir in "$_TUE_CATKIN_SYSTEM_DIR"/src/*/
+    for pkg_dir in "$TUE_SYSTEM_DIR"/src/*/
     do
         pkg=$(basename "$pkg_dir")
 
@@ -517,7 +517,7 @@ function tue-revert
 
 function tue-revert-undo
 {
-    for pkg_dir in "$_TUE_CATKIN_SYSTEM_DIR"/src/*/
+    for pkg_dir in "$TUE_SYSTEM_DIR"/src/*/
     do
         pkg=$(basename "$pkg_dir")
 
@@ -817,14 +817,14 @@ function tue-checkout
         shift
     done
 
-    fs=$(ls -d -1 "$_TUE_CATKIN_SYSTEM_DIR"/src/**)
+    fs=$(ls -d -1 "$TUE_SYSTEM_DIR"/src/**)
     if [ -z "$NO_TUE_ENV" ]
     then
         fs="$TUE_DIR $TUE_ENV_TARGETS_DIR $fs"
     fi
     for pkg_dir in $fs
     do
-        pkg=${pkg_dir#$_TUE_CATKIN_SYSTEM_DIR/src/}
+        pkg=${pkg_dir#$TUE_SYSTEM_DIR/src/}
         if [ -z "$NO_TUE_ENV" ]
         then
             if [[ $pkg =~ .tue ]]

--- a/setup/tue-functions.bash
+++ b/setup/tue-functions.bash
@@ -233,7 +233,7 @@ function tue-make
             catkin build --workspace "$TUE_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
             ;;
         '')
-            catkin init --workspace "$TUE_SYSTEM_DIR" "$@"
+            catkin config --init --mkdirs --workspace "$TUE_SYSTEM_DIR" "$@"
             catkin build --workspace "$TUE_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
             ;;
         esac
@@ -250,7 +250,7 @@ function tue-make-system
         catkin build --workspace "$TUE_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
         ;;
     '')
-        catkin init --workspace "$TUE_SYSTEM_DIR" "$@"
+        catkin config --init --mkdirs --workspace "$TUE_SYSTEM_DIR" "$@"
         catkin build --workspace "$TUE_SYSTEM_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
         ;;
     esac
@@ -276,7 +276,7 @@ function tue-make-dev
         catkin build --workspace "$TUE_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
         ;;
     '')
-        catkin init --workspace "$TUE_DEV_DIR" "$@"
+        catkin config --init --mkdirs --workspace "$TUE_DEV_DIR" "$@"
         catkin build --workspace "$TUE_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
         ;;
     esac
@@ -292,7 +292,7 @@ function tue-make-dev-isolated
         catkin build --workspace "$TUE_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
         ;;
     '')
-        catkin init --workspace "$TUE_DEV_DIR" "$@"
+        catkin config --init --mkdirs --workspace "$TUE_DEV_DIR" "$@"
         catkin build --workspace "$TUE_DEV_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
         ;;
     esac


### PR DESCRIPTION
- Also build release in CI
- Remove `--cmake-args` as it not needed and broke the usage of additional arguments
- Add build type to all build functions

Merge together with https://github.com/tue-robotics/tue-env-targets/pull/83