### PR TITLE
Commit range to determine changed packages

### DIFF
--- a/ci/.travis.yml.multiple_pkgs.example
+++ b/ci/.travis.yml.multiple_pkgs.example
@@ -11,7 +11,7 @@ before_install:
   - wget https://raw.githubusercontent.com/tue-robotics/tue-env/master/ci/packages.sh
   # Determine packages modified in this commit
   - ALL=$([ $TRAVIS_EVENT_TYPE == "cron" ] && echo "true")
-  - source packages.sh --pullrequest=$TRAVIS_PULL_REQUEST --branch=$TRAVIS_BRANCH --all=$ALL # add all folders which need to be excluded as an argument
+  - source packages.sh --commit-range=$TRAVIS_COMMIT_RANGE --all=$ALL # add all folders which need to be excluded as an argument
 
 env:
   # Run following in root of repo:

--- a/ci/azure-pipelines.yml.multiple_pkgs.example
+++ b/ci/azure-pipelines.yml.multiple_pkgs.example
@@ -13,9 +13,11 @@ jobs:
         inputs:
           targetType: 'inline'
           script: |
-            wget https://raw.githubusercontent.com/tue-robotics/tue-env/feature/azure_scripts/ci/packages.sh
+            wget https://raw.githubusercontent.com/tue-robotics/tue-env/master/ci/packages.sh
+            wget https://raw.githubusercontent.com/tue-robotics/tue-env/master/ci/azure_commit_range.py
+            COMMIT_RANGE=$(python azure_commit_range.py)
             ALL=$([ $BUILD_REASON == "Schedule" ] && echo "true")
-            source ./packages.sh --pullrequest=${SYSTEM_PULLREQUEST_PULLREQUESTNUMBER:-false} --branch=$SYSTEM_PULLREQUEST_TARGETBRANCH --all=$ALL # add all folders which need to be excluded as an argument
+            source ./packages.sh --commit-range=$COMMIT_RANGE --all=$ALL # add all folders which need to be excluded as an argument
             echo "##vso[task.setVariable variable=json_string;isOutput=true]$PACKAGES_DICT"
     
   - job: install_build_test

--- a/ci/azure-pipelines.yml.multiple_pkgs.example
+++ b/ci/azure-pipelines.yml.multiple_pkgs.example
@@ -15,7 +15,7 @@ jobs:
           script: |
             wget https://raw.githubusercontent.com/tue-robotics/tue-env/master/ci/packages.sh
             wget https://raw.githubusercontent.com/tue-robotics/tue-env/master/ci/azure_commit_range.py
-            COMMIT_RANGE=$(python azure_commit_range.py)
+            export COMMIT_RANGE=$(python azure_commit_range.py)
             ALL=$([ $BUILD_REASON == "Schedule" ] && echo "true")
             source ./packages.sh --commit-range=$COMMIT_RANGE --all=$ALL # add all folders which need to be excluded as an argument
             echo "##vso[task.setVariable variable=json_string;isOutput=true]$PACKAGES_DICT"

--- a/ci/azure-pipelines.yml.multiple_pkgs.example
+++ b/ci/azure-pipelines.yml.multiple_pkgs.example
@@ -17,7 +17,7 @@ jobs:
             wget https://raw.githubusercontent.com/tue-robotics/tue-env/master/ci/azure_commit_range.py
             export COMMIT_RANGE=$(python azure_commit_range.py)
             ALL=$([ $BUILD_REASON == "Schedule" ] && echo "true")
-            source ./packages.sh --commit-range=$COMMIT_RANGE --all=$ALL # add all folders which need to be excluded as an argument
+            source ./packages.sh --pullrequest=${SYSTEM_PULLREQUEST_PULLREQUESTNUMBER:-false} --branch=$SYSTEM_PULLREQUEST_TARGETBRANCH --commit-range=$COMMIT_RANGE --all=$ALL # add all folders which need to be excluded as an argument
             echo "##vso[task.setVariable variable=json_string;isOutput=true]$PACKAGES_DICT"
     
   - job: install_build_test

--- a/ci/azure_commit_range.py
+++ b/ci/azure_commit_range.py
@@ -34,10 +34,3 @@ newest_commit = json_data["value"][0]["id"]
 oldest_commit = json_data["value"][number_commits-1]["id"]
 commit_range = "{}...{}".format(newest_commit, oldest_commit)
 print(commit_range)
-
-
-
-
-
-
-

--- a/ci/azure_commit_range.py
+++ b/ci/azure_commit_range.py
@@ -5,6 +5,16 @@ import os
 import sys
 import urllib
 
+"""
+Script to determine the commit range of a build in azure pipelines.
+
+The output of this script should be captured in bash. The output
+will match the format of TRAVIS_COMMIT_RANGE, which is
+newest_commit...oldest_commit
+
+If the range is just 1 commit, an empty string is printed.
+"""
+
 TEAM_FOUNDATION_URI = os.getenv("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI")
 TEAM_PROJECT = os.getenv("SYSTEM_TEAMPROJECT")
 BUILD_ID = os.getenv("BUILD_BUILDID")

--- a/ci/azure_commit_range.py
+++ b/ci/azure_commit_range.py
@@ -1,4 +1,4 @@
-# commit_range.py
+from __future__ import print_function
 
 import json
 import os

--- a/ci/azure_commit_range.py
+++ b/ci/azure_commit_range.py
@@ -22,8 +22,7 @@ BUILD_ID = os.getenv("BUILD_BUILDID")
 TEAM_FOUNDATION_URI = TEAM_FOUNDATION_URI.rstrip("/")
 
 json_url = "{}/{}/_apis/build/builds/{}/changes?&$top=500&includeSourceChange=true&api-version=5.0".format(
-    TEAM_FOUNDATION_URI, TEAM_PROJECT, BUILD_ID
-)
+    TEAM_FOUNDATION_URI, TEAM_PROJECT, BUILD_ID)
 
 json_response = urllib.urlopen(json_url)
 json_data = json.loads(json_response.read())

--- a/ci/azure_commit_range.py
+++ b/ci/azure_commit_range.py
@@ -8,7 +8,7 @@ import urllib
 """
 Script to determine the commit range of a build in azure pipelines.
 
-The output of this script should be captured in bash. The output
+The output of this script should be captured in bash. The out               put
 will match the format of TRAVIS_COMMIT_RANGE, which is
 newest_commit...oldest_commit
 

--- a/ci/azure_commit_range.py
+++ b/ci/azure_commit_range.py
@@ -1,0 +1,31 @@
+# commit_range.py
+
+import json
+import os
+import sys
+import urllib
+
+TEAM_FOUNDATION_URI = os.getenv("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI")
+TEAM_PROJECT = os.getenv("SYSTEM_TEAMPROJECT")
+BUILD_ID = os.getenv("BUILD_BUILDID")
+
+TEAM_FOUNDATION_URI = TEAM_FOUNDATION_URI.rstrip("/")
+
+json_url = "{}/{}/_apis/build/builds/{}/changes?&$top=500&includeSourceChange=true&api-version=5.0".format(
+    TEAM_FOUNDATION_URI, TEAM_PROJECT, BUILD_ID
+)
+
+json_response = urllib.urlopen(json_url)
+json_data = json.loads(json_response.read())
+number_commits = json_data["count"]
+newest_commit = json_data["value"][0]["id"]
+oldest_commit = json_data["value"][number_commits-1]["id"]
+commit_range = "{}...{}".format(newest_commit, oldest_commit)
+print(commit_range)
+
+
+
+
+
+
+

--- a/ci/azure_commit_range.py
+++ b/ci/azure_commit_range.py
@@ -18,6 +18,9 @@ json_url = "{}/{}/_apis/build/builds/{}/changes?&$top=500&includeSourceChange=tr
 json_response = urllib.urlopen(json_url)
 json_data = json.loads(json_response.read())
 number_commits = json_data["count"]
+if number_commits == 1:
+    print("")
+    exit(0)
 newest_commit = json_data["value"][0]["id"]
 oldest_commit = json_data["value"][number_commits-1]["id"]
 commit_range = "{}...{}".format(newest_commit, oldest_commit)


### PR DESCRIPTION
Right now the CI only checks the modified packages against the last commit in a push. (in a PR, all commits are checked.) If you don't push every commit separately, these commit are put together in one build. But the still only the last commit was used to check for changed packages.

If this PR, this is fixed. For Travis, there is already a variable available. For azure, a script is needed to generate this. A external API is used to determine this. Azure is inconsistent and sometimes only provides one commit, while multiple commits were added since the last push. Therefore the script returns an empty string the case of just one commit. `Packages.sh` falls back to old implementation.

Update: Azure limits the number of commits to 200. In that case, the old method would be better.