### PR TITLE
move target import to end

### DIFF
--- a/setup.bash
+++ b/setup.bash
@@ -58,12 +58,6 @@ then
     source "$TUE_ENV_DIR"/.env/setup/user_setup.bash
 fi
 
-if [ -f "$TUE_ENV_DIR"/.env/setup/target_setup.bash ]
-then
-    # shellcheck disable=SC1090
-    source "$TUE_ENV_DIR"/.env/setup/target_setup.bash
-fi
-
 # -----------------------------------------
 # Load all the bash functions
 # shellcheck disable=SC1090
@@ -78,3 +72,8 @@ fi
 export TUE_BIN=$TUE_DIR/bin
 export PATH=$TUE_BIN${PATH:+:${PATH}}
 
+if [ -f "$TUE_ENV_DIR"/.env/setup/target_setup.bash ]
+then
+    # shellcheck disable=SC1090
+    source "$TUE_ENV_DIR"/.env/setup/target_setup.bash
+fi


### PR DESCRIPTION
So targets can use all functions and variables defined above. Like the `qtcreator` target which requires TUE_SYSTEM_DIR, which is defined in tue-functions