### PR TITLE
Cleanup existing apt lists before update

### DIFF
--- a/setup/tue-functions.bash
+++ b/setup/tue-functions.bash
@@ -51,6 +51,8 @@ function tue-apt-select-mirror
         echo -e "Updating the apt mirror with the fastest one"
         sudo cp /etc/apt/sources.list /etc/apt/sources.list.bk
         sudo cp /tmp/sources.list /etc/apt/sources.list
+        echo -e "Cleaning up existing apt lists in /var/lib/apt/lists"
+        sudo rm -rf /var/lib/apt/lists/*
         echo -e "Running: sudo apt-get update -qq"
         sudo apt-get update -qq
     fi

--- a/setup/tue-functions.bash
+++ b/setup/tue-functions.bash
@@ -32,30 +32,30 @@ function tue-apt-select-mirror
     # It uses apt-select to generate a new sources.list, based on the current one.
     # All Arguments to this functions are passed on to apt-select, so check the
     # apt-select documentation for all options.
-	hash pip2 2> /dev/null|| sudo apt-get install --assume-yes python-pip
-	hash apt-select 2> /dev/null|| sudo -H pip2 install apt-select
+    hash pip2 2> /dev/null|| sudo apt-get install --assume-yes python-pip
+    hash apt-select 2> /dev/null|| sudo -H pip2 install apt-select
 
-	local mem_pwd=$PWD
+    local mem_pwd=$PWD
     # shellcheck disable=SC2164
-	cd /tmp
-	local err_code
-	apt-select "$@" 2> /dev/null
-	err_code=$?
-	if [ $err_code == 4 ]
-	then
-		echo -e "Fastest apt mirror is the current one"
-	elif [ $err_code != 0 ]
+    cd /tmp
+    local err_code
+    apt-select "$@" 2> /dev/null
+    err_code=$?
+    if [ $err_code == 4 ]
+    then
+        echo -e "Fastest apt mirror is the current one"
+    elif [ $err_code != 0 ]
     then
         echo -e "Non zero error code return by apt-select: $err_code"
     else
-		echo -e "Updating the apt mirror with the fastest one"
-		sudo cp /etc/apt/sources.list /etc/apt/sources.list.bk
-		sudo cp /tmp/sources.list /etc/apt/sources.list
-		echo -e "Running: sudo apt-get update -qq"
-		sudo apt-get update -qq
-	fi
+        echo -e "Updating the apt mirror with the fastest one"
+        sudo cp /etc/apt/sources.list /etc/apt/sources.list.bk
+        sudo cp /tmp/sources.list /etc/apt/sources.list
+        echo -e "Running: sudo apt-get update -qq"
+        sudo apt-get update -qq
+    fi
     # shellcheck disable=SC2164
-	cd "$mem_pwd"
+    cd "$mem_pwd"
 }
 
 # ----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
`apt` mirrors face a race condition during updates. If the new mirror selected is was different than the existing one, there can be a `Hash sum mismatch` error.

One easy fix to this problem is to reset the existing lists by downloading them again.

An elegant fix is to only download lists that have this error, but would require excess tooling.