### PR TITLE
Fix hsr targets hack

### DIFF
--- a/installer/tue-install-impl.bash
+++ b/installer/tue-install-impl.bash
@@ -634,12 +634,6 @@ function tue-install-ros
     then
         tue-install-debug "tue-install-system ros-$TUE_ROS_DISTRO-$src"
 
-        # all HSR system targets from Toyota need extra apt sources
-        if [[ $src == *"hsr"* ||  "$src" == *"tmc"* ]]
-        then
-            tue-install-target hsr-setup || tue-install-error "Failed to install target 'hsr-setup'"
-        fi
-
         tue-install-system ros-"$TUE_ROS_DISTRO"-"$src"
         return 0
     fi


### PR DESCRIPTION
These lines shouldn't be here. Dependencies need to be specified in the targets, not in the package manager.

Merge along with tue-robotics/tue-env-targets#102