### PR TITLE
Fix path issues of local installs in CI

### DIFF
--- a/setup.bash
+++ b/setup.bash
@@ -70,7 +70,17 @@ then
 fi
 
 export TUE_BIN=$TUE_DIR/bin
-export PATH=$TUE_BIN${PATH:+:${PATH}}
+
+# .local/bin is needed in the path for all user installs like pip. It gets added automatically on reboot but not on CI
+if [[ :$PATH: != *:$HOME/.local/bin:* ]]
+then
+    export PATH=$HOME/.local/bin${PATH:+:${PATH}}
+fi
+
+if [[ :$PATH: != *:$TUE_BIN:* ]]
+then
+    export PATH=$TUE_BIN${PATH:+:${PATH}}
+fi
 
 if [ -f "$TUE_ENV_DIR"/.env/setup/target_setup.bash ]
 then


### PR DESCRIPTION
Needed for CI and automatically added to path on a normal PC after a reboot.

Fixes tue-robotics/tue-env-targets#137