### PR TITLE
Fix Azure CI

### DIFF
--- a/ci/build-package.sh
+++ b/ci/build-package.sh
@@ -42,12 +42,12 @@ fi
 # Use docker environment variables in all exec commands instead of script variables
 # Compile the package
 echo -e "\e[35m\e[1m Compile the package (catkin build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCATKIN_ENABLE_TESTING=OFF) \e[0m"
-docker exec -it tue-env bash -c 'source ~/.bashrc; cd "$TUE_SYSTEM_DIR"/src/"$PACKAGE" && catkin build --this --no-status -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCATKIN_ENABLE_TESTING=OFF'
+docker exec -t tue-env bash -c 'source ~/.bashrc; cd "$TUE_SYSTEM_DIR"/src/"$PACKAGE" && catkin build --this --no-status -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCATKIN_ENABLE_TESTING=OFF'
 
 # Run unit tests
 echo -e "\e[35m\e[1m Run tests on this package (catkin run_tests --this --no-deps -DCATKIN_ENABLE_TESTING=ON) \e[0m"
-docker exec -it tue-env bash -c 'source ~/.bashrc; cd "$TUE_SYSTEM_DIR"/src/"$PACKAGE" && catkin run_tests --this --no-status --no-deps -DCATKIN_ENABLE_TESTING=ON'
+docker exec -t tue-env bash -c 'source ~/.bashrc; cd "$TUE_SYSTEM_DIR"/src/"$PACKAGE" && catkin run_tests --this --no-status --no-deps -DCATKIN_ENABLE_TESTING=ON'
 
 # Check results of unit tests
 echo -e "\e[35m\e[1m Check results of the tests on this package (catkin_test_results build/$PACKAGE) \e[0m"
-docker exec -it tue-env bash -c 'source ~/.bashrc; cd "$TUE_SYSTEM_DIR" && [ ! -d build/"$PACKAGE" ] || catkin_test_results build/"$PACKAGE"'
+docker exec -t tue-env bash -c 'source ~/.bashrc; cd "$TUE_SYSTEM_DIR" && [ ! -d build/"$PACKAGE" ] || catkin_test_results build/"$PACKAGE"'

--- a/ci/install-package.sh
+++ b/ci/install-package.sh
@@ -110,7 +110,7 @@ fi
 # shellcheck disable=SC2086
 docker run --detach --interactive --tty -e CI="true" -e PACKAGE="$PACKAGE" -e BRANCH="$BRANCH" -e COMMIT="$COMMIT" -e PULL_REQUEST="$PULL_REQUEST" --name tue-env $DOCKER_MOUNT_KNOWN_HOSTS_ARGS "$IMAGE_NAME:$BRANCH_TAG"
 
-if [ $MERGE_KNOWN_HOSTS == "true" ]
+if [ "$MERGE_KNOWN_HOSTS" == "true" ]
 then
     docker exec -it tue-env bash -c "sudo chown 1000:1000 /tmp/known_hosts_extra && ~/.tue/ci/ssh-merge-known_hosts.py ~/.ssh/known_hosts /tmp/known_hosts_extra --output ~/.ssh/known_hosts"
 fi

--- a/ci/install-package.sh
+++ b/ci/install-package.sh
@@ -112,21 +112,21 @@ docker run --detach --interactive --tty -e CI="true" -e PACKAGE="$PACKAGE" -e BR
 
 if [ "$MERGE_KNOWN_HOSTS" == "true" ]
 then
-    docker exec -it tue-env bash -c "sudo chown 1000:1000 /tmp/known_hosts_extra && ~/.tue/ci/ssh-merge-known_hosts.py ~/.ssh/known_hosts /tmp/known_hosts_extra --output ~/.ssh/known_hosts"
+    docker exec -t tue-env bash -c "sudo chown 1000:1000 /tmp/known_hosts_extra && ~/.tue/ci/ssh-merge-known_hosts.py ~/.ssh/known_hosts /tmp/known_hosts_extra --output ~/.ssh/known_hosts"
 fi
 
 if [ "$USE_SSH" == "true" ]
 then
-    docker exec -it tue-env bash -c "eval $(ssh-agent -s)"
-    docker exec -it tue-env bash -c "echo '$SSH_KEY' > ~/.ssh/id_rsa && chmod 700 ~/.ssh/id_rsa"
+    docker exec -t tue-env bash -c "eval $(ssh-agent -s)"
+    docker exec -t tue-env bash -c "echo '$SSH_KEY' > ~/.ssh/id_rsa && chmod 700 ~/.ssh/id_rsa"
 fi
 
 # Refresh the apt cache in the docker image
-docker exec -it tue-env bash -c 'sudo apt-get update -qq'
+docker exec -t tue-env bash -c 'sudo apt-get update -qq'
 
 # Use docker environment variables in all exec commands instead of script variables
 # Catch the ROS_DISTRO of the docker container
-ROS_DISTRO=$(docker exec -it tue-env bash -c 'source ~/.bashrc; echo "$ROS_DISTRO"')
+ROS_DISTRO=$(docker exec -t tue-env bash -c 'source ~/.bashrc; echo "$ROS_DISTRO"')
 echo -e "\e[35m\e[1m ROS_DISTRO = ${ROS_DISTRO}\e[0m"
 
 # Install the package
@@ -138,8 +138,8 @@ echo -e "\e[35m\e[1m Reset package to this commit \e[0m"
 if [[ $PULL_REQUEST == "false" ]]
 then
     echo -e "\e[35m\e[1m cd ~/ros/$ROS_DISTRO/system/src/$PACKAGE && git reset --hard $COMMIT \e[0m"
-    docker exec -it tue-env bash -c 'source ~/.bashrc; cd ~/ros/"$ROS_DISTRO"/system/src/"$PACKAGE" && git reset --hard "$COMMIT"'
+    docker exec -t tue-env bash -c 'source ~/.bashrc; cd ~/ros/"$ROS_DISTRO"/system/src/"$PACKAGE" && git reset --hard "$COMMIT"'
 else
     echo -e "\e[35m\e[1m cd ~/ros/$ROS_DISTRO/system/src/$PACKAGE && git fetch origin pull/$PULL_REQUEST/head:PULLREQUEST && git checkout PULLREQUEST \e[0m"
-    docker exec -it tue-env bash -c 'source ~/.bashrc; cd ~/ros/"$ROS_DISTRO"/system/src/"$PACKAGE" && git fetch origin pull/"$PULL_REQUEST"/head:PULLREQUEST && git checkout PULLREQUEST'
+    docker exec -t tue-env bash -c 'source ~/.bashrc; cd ~/ros/"$ROS_DISTRO"/system/src/"$PACKAGE" && git fetch origin pull/"$PULL_REQUEST"/head:PULLREQUEST && git checkout PULLREQUEST'
 fi


### PR DESCRIPTION
When using `-it` in docker exec, the container expects an interactive terminal to be connected.

To have only color outputs `-t` should be used.
To have interactive inputs like `input | docker ...` or `docker ... <input` `-i` is to be used

Tested it on both Azure (https://dev.azure.com/tue-robotics/tue-robotics/_build/results?buildId=1918&view=results) and Travis (https://travis-ci.com/github/tue-robotics/hero_bringup)

Delete branch `fix/azure-ci` in tue_robocup and hero_bringup upon merge.