### PR TITLE
Add target-now feature

### DIFF
--- a/installer/parse-install-yaml.py
+++ b/installer/parse-install-yaml.py
@@ -9,7 +9,7 @@ import yaml
 from lsb_release import get_distro_information
 
 ros_release = environ["TUE_ROS_DISTRO"]
-ubuntu_release = get_distro_information()['CODENAME']
+ubuntu_release = get_distro_information()["CODENAME"]
 
 
 def show_error(error):
@@ -60,8 +60,9 @@ def main():
                     elif "default" in install_item:
                         source = install_item["default"]["source"]
                     else:
-                        return show_error("ROS distro {} or 'default' not specified in install.yaml".
-                                          format(ros_release))
+                        return show_error(
+                            "ROS distro {} or 'default' not specified in install.yaml".format(ros_release)
+                        )
                     # Both release and default are allowed to be None
                     if source is None:
                         continue
@@ -83,8 +84,23 @@ def main():
                 if "version" in install_item:
                     command += " {0}".format(install_item["version"])
 
-            elif install_type in ["target", "system", "pip", "pip2", "pip3", "ppa", "snap", "dpkg",
-                                  "target-now", "system-now", "pip-now", "pip2-now", "pip3-now", "ppa-now", "snap-now"]:
+            elif install_type in [
+                "target",
+                "system",
+                "pip",
+                "pip2",
+                "pip3",
+                "ppa",
+                "snap",
+                "dpkg",
+                "target-now",
+                "system-now",
+                "pip-now",
+                "pip2-now",
+                "pip3-now",
+                "ppa-now",
+                "snap-now",
+            ]:
                 if now and "now" not in install_type:
                     install_type += "-now"
 
@@ -96,8 +112,9 @@ def main():
                     elif "default" in install_item:
                         pkg_name = install_item["default"]["name"]
                     else:
-                        return show_error("Ubuntu distro {} or 'default' not specified in install.yaml".
-                                          format(ubuntu_release))
+                        return show_error(
+                            "Ubuntu distro {} or 'default' not specified in install.yaml".format(ubuntu_release)
+                        )
                     # Both release and default are allowed to be None
                     if pkg_name is None:
                         continue

--- a/installer/parse-install-yaml.py
+++ b/installer/parse-install-yaml.py
@@ -18,9 +18,16 @@ def show_error(error):
 
 
 def main():
-    if len(sys.argv) != 2:
-        print("Usage: parse-install-yaml install.yaml")
+    if not 2 <= len(sys.argv) <= 3:
+        print("Usage: parse-install-yaml install.yaml [--now]")
         return 1
+
+    now = False
+    if len(sys.argv) == 3:
+        if sys.argv[2] == "--now":
+            now = True
+        else:
+            return show_error("Unknown option: {0}".format(sys.argv[2]))
 
     with open(sys.argv[1]) as f:
         try:
@@ -77,7 +84,10 @@ def main():
                     command += " {0}".format(install_item["version"])
 
             elif install_type in ["target", "system", "pip", "pip2", "pip3", "ppa", "snap", "dpkg",
-                                  "system-now", "pip-now", "pip2-now", "pip3-now", "ppa-now", "snap-now"]:
+                                  "target-now", "system-now", "pip-now", "pip2-now", "pip3-now", "ppa-now", "snap-now"]:
+                if now and "now" not in install_type:
+                    install_type += "-now"
+
                 if "name" in install_item:
                     pkg_name = install_item["name"]
                 else:

--- a/installer/tue-install-impl.bash
+++ b/installer/tue-install-impl.bash
@@ -91,13 +91,29 @@ function tue-install-debug
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
+function tue-install-target-now
+{
+    tue-install-debug "tue-install-target-now $*"
+
+    local target=$1
+
+    tue-install-debug "calling: tue-install-target $target true"
+    tue-install-target "$target" "true"
+}
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
 function tue-install-target
 {
     tue-install-debug "tue-install-target $*"
 
     local target=$1
+    local now=$2
 
-    tue-install-debug "Installing $target"
+    local now_cmd=""
+    [ "$now" == "true" ] && now_cmd="--now"
+
+    tue-install-debug "Installing target: $target"
 
     # Check if valid target received as input
     if [ ! -d "$TUE_INSTALL_TARGETS_DIR"/"$target" ]
@@ -124,7 +140,6 @@ function tue-install-target
     then
         tue-install-debug "File $TUE_INSTALL_STATE_DIR/$target does not exist, going to installation procedure"
 
-
         local install_file=$TUE_INSTALL_TARGETS_DIR/$target/install
 
         TUE_INSTALL_CURRENT_TARGET_DIR=$TUE_INSTALL_TARGETS_DIR/$target
@@ -140,7 +155,7 @@ function tue-install-target
             tue-install-debug "Parsing $install_file.yaml"
             # Do not use 'local cmds=' because it does not preserve command output status ($?)
             local cmds
-            if cmds=$("$TUE_INSTALL_SCRIPTS_DIR"/parse-install-yaml.py "$install_file".yaml)
+            if cmds=$("$TUE_INSTALL_SCRIPTS_DIR"/parse-install-yaml.py "$install_file".yaml $now_cmd)
             then
                 for cmd in $cmds
                 do
@@ -883,7 +898,7 @@ function _tue-install-pip-now
         python"${pv}" -m pip install --user --upgrade pip
         hash -r
     else
-        tue-install-debug "Already pip${pv}>=$desired_pip_version\n"
+        tue-install-debug "Already pip${pv}>=$desired_pip_version"
     fi
 
     local pips_to_check=""
@@ -1016,6 +1031,15 @@ function tue-install-snap-now
             yes | sudo snap install --classic "$pkg" || tue-install-error "An error occurred while installing snap packages."
         done
     fi
+}
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+function tue-install-dpkg-now
+{
+    tue-install-debug "tue-install-dpkg-now $*"
+    tue-install-debug "calling: tue-install-dpkg $*"
+    tue-install-dpkg "$@"
 }
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #


### PR DESCRIPTION
It installs the target and its dependencies directly, so these can be used during the execution of the install.bash script. Though ROS packages including dependencies, both system and git, are not converted to a now target, as ROS packages shouldn't be executed during install scripts.

I don't see the need for a command line option. As a target should only be converted to a now target in case that is needed by an other target.

