### PR TITLE
Correct error_handling of yaml install cmds

### DIFF
--- a/installer/tue-install-impl.bash
+++ b/installer/tue-install-impl.bash
@@ -99,6 +99,7 @@ function tue-install-target-now
 
     tue-install-debug "calling: tue-install-target $target true"
     tue-install-target "$target" "true"
+    return $?
 }
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -159,8 +160,8 @@ function tue-install-target
             then
                 for cmd in $cmds
                 do
-                    tue-install-debug "Running following command: $cmd"
-                    ${cmd//^/ }
+                    tue-install-debug "Running following command:  ${cmd//^/ }"
+                    ${cmd//^/ } || tue-install-error "Error while running: ${cmd//^/ }"
                 done
                 target_processed=true
             else


### PR DESCRIPTION
If a target exists an error is not thrown because we want to check if the target with a ros prefix exists. But this causes a problem for not ros targets depending on other targets. Therefore the return code of cmds should be checked