### PR TITLE
(actions) remove continue-on-error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,6 @@ jobs:
   linting:
     name: Linting
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python 3


### PR DESCRIPTION
`continue-on-error` causes for the action to continue to run docker generation, while this shouldn't. This shouldn't have been there in the first place.

This fixes this incorrect behaviour: https://github.com/tue-robotics/tue-env/actions/runs/420599094