### PR TITLE
(CI)(commit-range) fix range for rebase pushes

### DIFF
--- a/ci/commit-range/action.yml
+++ b/ci/commit-range/action.yml
@@ -14,12 +14,14 @@ runs:
       run: |
         if [ "${GITHUB_EVENT_NAME}" == "push" ]
         then
-          COMMIT_RANGE=${{ github.event.compare }}
-          if [[ "${COMMIT_RANGE}" == *"..."* ]] && [[ $(echo "${commit_list}" | jq '. | length') > 1 ]]
+          NUMBER_COMMITS=$(echo "${commit_list}" | jq 'length')
+          if [ ${NUMBER_COMMITS} -le 1 ]
           then
-            COMMIT_RANGE=${COMMIT_RANGE#https://github.com/${{ github.repository }}/compare/}
-          else
             COMMIT_RANGE=""
+          else
+            OLDEST=$(echo "${commit_list}" | jq 'first.id')
+            NEWEST=$(echo "${commit_list}" | jq 'last.id')
+            COMMIT_RANGE="${OLDEST}^2...${NEWEST}" # Take second parent, see https://stackoverflow.com/a/2222920
           fi
         elif [ "${GITHUB_EVENT_NAME}" == "pull_request" ]
         then

--- a/ci/commit-range/action.yml
+++ b/ci/commit-range/action.yml
@@ -19,8 +19,8 @@ runs:
           then
             COMMIT_RANGE=""
           else
-            OLDEST=$(echo "${commit_list}" | jq 'first.id')
-            NEWEST=$(echo "${commit_list}" | jq 'last.id')
+            OLDEST=$(echo "${commit_list}" | jq 'first.id' | tr -d '"')
+            NEWEST=$(echo "${commit_list}" | jq 'last.id' | tr -d '"')
             OLDEST_PARENTS=($(git show --no-patch --format="%P" ${OLDEST}))
             NUMBER_OLDEST_PARENTS=${#OLDEST_PARENTS[@]}
             COMMIT_RANGE="${OLDEST}^${NUMBER_OLDEST_PARENTS}...${NEWEST}" # Take second parent if possible, see https://stackoverflow.com/a/2222920

--- a/ci/commit-range/action.yml
+++ b/ci/commit-range/action.yml
@@ -21,7 +21,9 @@ runs:
           else
             OLDEST=$(echo "${commit_list}" | jq 'first.id')
             NEWEST=$(echo "${commit_list}" | jq 'last.id')
-            COMMIT_RANGE="${OLDEST}^2...${NEWEST}" # Take second parent, see https://stackoverflow.com/a/2222920
+            OLDEST_PARENTS=($(git show --no-patch --format="%P" ${OLDEST}))
+            NUMBER_OLDEST_PARENTS=${#OLDEST_PARENTS[@]}
+            COMMIT_RANGE="${OLDEST}^${NUMBER_OLDEST_PARENTS}...${NEWEST}" # Take second parent if possible, see https://stackoverflow.com/a/2222920
           fi
         elif [ "${GITHUB_EVENT_NAME}" == "pull_request" ]
         then


### PR DESCRIPTION
This should fix the issue in https://github.com/tue-robotics/ed_sensor_integration/runs/1674923505?check_suite_focus=true#step:4:9

I have tested this on my laptop with and older repo and a fresh clone. I can reproduce the error on the fresh clone. But the current implementation does work on my old repo, because it has commits from before rebasing.

The new solution does work on both repos and has the same output. I can't fully test the new solution as I don't have the full GitHub context, but I have tested all separate parts with a fake commit_list.

After we merge the new solution we can rerun the failing action, which should succeed then.