### PR TITLE
(actions) don't update docker

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,8 @@ jobs:
     needs: linting
     steps:
       - uses: actions/checkout@v2
+      - name: Docker info
+        run: docker info
       - name: Script
         run: ci/build-docker-image.sh --image="tuerobotics/tue-env" --branch="${GITHUB_BASE_REF:-${GITHUB_REF#refs/heads/}}" --commit="$GITHUB_SHA" --pull_request="${{ github.event_name == 'pull_request' }}" --user="${{ secrets.DOCKER_HUB_USERNAME }}" --password="${{ secrets.DOCKER_HUB_PASSWORD }}"
 
@@ -37,6 +39,8 @@ jobs:
     if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/master' }}
     steps:
       - uses: actions/checkout@v2
+      - name: Docker info
+        run: docker info
       - name: Script
         run: ci/build-docker-image.sh --image="tuerobotics/tue-env-cuda" --branch="${GITHUB_BASE_REF:-${GITHUB_REF#refs/heads/}}" --commit="$GITHUB_SHA" --pull_request="${{ github.event_name == 'pull_request' }}" --user="${{ secrets.DOCKER_HUB_USERNAME }}" --password="${{ secrets.DOCKER_HUB_PASSWORD }}"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,8 +27,6 @@ jobs:
     needs: linting
     steps:
       - uses: actions/checkout@v2
-      - name: Install
-        run: ci/update-docker.bash
       - name: Script
         run: ci/build-docker-image.sh --image="tuerobotics/tue-env" --branch="${GITHUB_BASE_REF:-${GITHUB_REF#refs/heads/}}" --commit="$GITHUB_SHA" --pull_request="${{ github.event_name == 'pull_request' }}" --user="${{ secrets.DOCKER_HUB_USERNAME }}" --password="${{ secrets.DOCKER_HUB_PASSWORD }}"
 
@@ -39,8 +37,6 @@ jobs:
     if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/master' }}
     steps:
       - uses: actions/checkout@v2
-      - name: Install
-        run: ci/update-docker.bash
       - name: Script
         run: ci/build-docker-image.sh --image="tuerobotics/tue-env-cuda" --branch="${GITHUB_BASE_REF:-${GITHUB_REF#refs/heads/}}" --commit="$GITHUB_SHA" --pull_request="${{ github.event_name == 'pull_request' }}" --user="${{ secrets.DOCKER_HUB_USERNAME }}" --password="${{ secrets.DOCKER_HUB_PASSWORD }}"
 


### PR DESCRIPTION
There is no need to update as both the [generation](https://github.com/tue-robotics/tue-env/runs/1800614259?check_suite_focus=true) seems to work correctly and also the use with ssh in [`hero_bridge`](https://github.com/tue-robotics/hero_bridge/runs/1800625916?check_suite_focus=true).

From the [documentation](https://github.com/actions/virtual-environments/blob/ubuntu18/20210123.1/images/linux/Ubuntu1804-README.md) it is unclear what version of docker is used. But it seems to work...