### PR TITLE
(Docker) remove temp tue files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,8 @@ RUN --mount=type=ssh,uid=1000 sed -e s/return//g -i ~/.bashrc && \
     tue-env config ros-"$TUE_ROS_DISTRO" git-use-https && \
     # Install target ros
     tue-get install ros --test-depend --branch="$BRANCH" && \
+    # Remove temp tue files
+    (rm -rf /tmp/tue* > /dev/null || true) && \
     # Show ownership of .tue
     namei -l ~/.tue && \
     # Check git remote origin

--- a/ci/install-package.sh
+++ b/ci/install-package.sh
@@ -127,9 +127,6 @@ then
     docker exec -t tue-env bash -c "eval $(ssh-agent -s)"
 fi
 
-# Refresh the apt cache in the docker image
-docker exec -t tue-env bash -c 'sudo apt-get update -qq'
-
 # Use docker environment variables in all exec commands instead of script variables
 # Catch the ROS_DISTRO of the docker container
 # stip carriage return from docker output by "tr -d '\r'"


### PR DESCRIPTION
This way we can strip the forced apt update in the `install-package.sh` script