### PR TITLE
pip: use new dep resolver

### DIFF
--- a/installer/tue-install-impl.bash
+++ b/installer/tue-install-impl.bash
@@ -983,9 +983,9 @@ function _tue-install-pip-now
     if [ -n "$pips_to_install" ]
     then
         echo -e "Going to run the following command:\n"
-        echo -e "python${pv} -m pip install --user $pips_to_install <<< yes\n"
+        echo -e "python${pv} -m pip install --use-feature=2020-resolver --use-feature=fast-deps --user $pips_to_install <<< yes\n"
         # shellcheck disable=SC2048,SC2086
-        python"${pv}" -m pip install --user $pips_to_install <<< yes || tue-install-error "An error occurred while installing pip${pv} packages."
+        python"${pv}" -m pip install --use-feature=2020-resolver --use-feature=fast-deps --user $pips_to_install <<< yes || tue-install-error "An error occurred while installing pip${pv} packages."
     fi
 
     if [ -n "$git_pips_to_install" ]
@@ -993,9 +993,9 @@ function _tue-install-pip-now
         for pkg in $git_pips_to_install
         do
             echo -e "Going to run the following command:\n"
-            echo -e "python${pv} -m pip install --user $pkg <<< yes\n"
+            echo -e "python${pv} -m pip install --use-feature=2020-resolver --use-feature=fast-deps --user $pkg <<< yes\n"
             # shellcheck disable=SC2048,SC2086
-            python"${pv}" -m pip install --user $pkg <<< yes || tue-install-error "An error occurred while installing pip${pv} packages."
+            python"${pv}" -m pip install --use-feature=2020-resolver --use-feature=fast-deps --user $pkg <<< yes || tue-install-error "An error occurred while installing pip${pv} packages."
         done
     fi
 }


### PR DESCRIPTION
Old pip dependency resolver does not consider dependency conflicts when selecting packages. The new resolver fixes this.

See image_recognition_keras:
![Screenshot from 2021-02-10 13-29-27](https://user-images.githubusercontent.com/18014833/107510657-998e9900-6ba4-11eb-8986-8d4f33d92adb.png)
