### PR TITLE
tue-install-apt-get-update

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ generally used methods of installing packages:
 | Function Name                   | Description                                                                                    |
 |---------------------------------|------------------------------------------------------------------------------------------------|
 | `tue-install-add-text`          | To add/replace text in a file with `sudo` taken into account                                   |
+| `tue-install-apt-get-update`    | Make sure that during next `tue-install-system-now` call `apt-get` is updated                  |
 | `tue-install-cp`                | Analogous to `cp` but takes `sudo` into account and the source should be relative to target    |
 | `tue-install-dpkg`              | To install a debian dpkg file                                                                  |
 | `tue-install-git`               | To install a git repository                                                                    |

--- a/installer/tue-install-impl.bash
+++ b/installer/tue-install-impl.bash
@@ -792,7 +792,7 @@ function tue-install-system-now
         then
             # Update once every boot. Or delete the tmp file if you need an update before installing a pkg.
             tue-install-debug "sudo apt-get update -qq"
-            sudo apt-get update -qq
+            sudo apt-get update -qq || tue-install-error "An error occurred while updating apt-get."
             touch $TUE_APT_GET_UPDATED_FILE
         fi
 

--- a/installer/tue-install-impl.bash
+++ b/installer/tue-install-impl.bash
@@ -25,6 +25,8 @@ TUE_INSTALL_TARGETS_DIR=$TUE_ENV_TARGETS_DIR
 
 TUE_REPOS_DIR=$TUE_ENV_DIR/repos
 
+TUE_APT_GET_UPDATED_FILE=/tmp/tue_get_apt_get_updated
+
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 function date_stamp
@@ -786,13 +788,12 @@ function tue-install-system-now
             ((i=i+1))
         done
 
-        local apt_get_updated=/tmp/tue_get_apt_get_updated
-        if [ ! -f "$apt_get_updated" ]
+        if [ ! -f "$TUE_APT_GET_UPDATED_FILE" ]
         then
             # Update once every boot. Or delete the tmp file if you need an update before installing a pkg.
             tue-install-debug "sudo apt-get update -qq"
             sudo apt-get update -qq
-            touch $apt_get_updated
+            touch $TUE_APT_GET_UPDATED_FILE
         fi
 
         tue-install-debug "sudo apt-get install --assume-yes -q $pkgs_to_install"
@@ -800,6 +801,15 @@ function tue-install-system-now
         sudo apt-get install --assume-yes -q $pkgs_to_install || tue-install-error "An error occurred while installing system packages."
         tue-install-debug "Installed $pkgs_to_install ($?)"
     fi
+}
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+function tue-install-apt-get-update
+{
+    tue-install-debug "tue-install-apt-get-update"
+    tue-install-debug "Requiring an update of apt-get before next 'apt-get install'"
+    rm -f $TUE_APT_GET_UPDATED_FILE
 }
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -873,8 +883,7 @@ function tue-install-ppa-now
     done
     if [ -n "$PPA_ADDED" ]
     then
-        tue-install-debug "sudo apt-get update -qq"
-        sudo apt-get update -qq
+        tue-install-apt-get-update
     fi
 }
 


### PR DESCRIPTION
Many targets would run an update after adding an apt source. This makes sure that we only run one `apt-get update`.

It could be that the added source is incorrect, which would normally show up during the target and not later on. Though none of these targets checked the return code, so that check wasn't happening anyway.

So we should either accept it and run one update on the next call of `tue-install-system-now` or we should add checks to the return code in the targets.