### PR TITLE
(pip) don't check for version if only git pip targets

### DIFF
--- a/installer/tue-install-impl.bash
+++ b/installer/tue-install-impl.bash
@@ -963,11 +963,14 @@ function _tue-install-pip-now
 
     read -r -a pips_to_check <<< "$pips_to_check"
     local installed_versions
-    installed_versions=$(python"${pv}" "$TUE_INSTALL_SCRIPTS_DIR"/check-pip-pkg-installed-version.py "${pips_to_check[@]}")
-    local error_code=$?
-    if [ "$error_code" -gt 1 ]
+    if [ ${#pips_to_check[@]} -gt 0 ]
     then
-        tue-install-error "tue-install-pip${pv}-now: $installed_versions"
+        installed_versions=$(python"${pv}" "$TUE_INSTALL_SCRIPTS_DIR"/check-pip-pkg-installed-version.py "${pips_to_check[@]}")
+        local error_code=$?
+        if [ "$error_code" -gt 1 ]
+        then
+            tue-install-error "tue-install-pip${pv}-now: $installed_versions"
+        fi
     fi
     read -r -a installed_versions <<< "$installed_versions"
 


### PR DESCRIPTION
When only installing git pip targets, the script to check the versions of the installed pkgs doesn't get any argument. So the script will return a non-zero error-code. This stops the installer, while nothing is wrong. So only check if the length is greater than zero.