### PR TITLE
(actions) better parsing of branch and pr vars

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,13 @@ jobs:
       - name: Docker info
         run: docker info
       - name: Script
-        run: ci/build-docker-image.sh --image="tuerobotics/tue-env" --branch="${GITHUB_BASE_REF:-${GITHUB_REF#refs/heads/}}" --commit="$GITHUB_SHA" --pull_request="${{ github.event_name == 'pull_request' }}" --user="${{ secrets.DOCKER_HUB_USERNAME }}" --password="${{ secrets.DOCKER_HUB_PASSWORD }}"
+        run: |
+          GITHUB_REF=${GITHUB_REF#refs/heads/}
+          GITHUB_REF=${GITHUB_REF#refs/tags/}
+          BRANCH=${GITHUB_BASE_REF:-${GITHUB_REF}}
+          PULLREQUEST=${{ github.event.number }}
+          PULLREQUEST=${PULLREQUEST:-false}
+          ci/build-docker-image.sh --image="tuerobotics/tue-env" --branch="${BRANCH}" --commit="$GITHUB_SHA" --pull_request="${PULLREQUEST}" --user="${{ secrets.DOCKER_HUB_USERNAME }}" --password="${{ secrets.DOCKER_HUB_PASSWORD }}"
 
   docker_generation_tue_env_cuda:
     name: Docker Generation tue-env-cuda
@@ -45,5 +51,11 @@ jobs:
       - name: Docker info
         run: docker info
       - name: Script
-        run: ci/build-docker-image.sh --image="tuerobotics/tue-env-cuda" --branch="${GITHUB_BASE_REF:-${GITHUB_REF#refs/heads/}}" --commit="$GITHUB_SHA" --pull_request="${{ github.event_name == 'pull_request' }}" --user="${{ secrets.DOCKER_HUB_USERNAME }}" --password="${{ secrets.DOCKER_HUB_PASSWORD }}"
-
+        run: |
+          GITHUB_REF=${GITHUB_REF#refs/heads/}
+          GITHUB_REF=${GITHUB_REF#refs/tags/}
+          BRANCH=${GITHUB_BASE_REF:-${GITHUB_REF}}
+          PULLREQUEST=${{ github.event.number }}
+          PULLREQUEST=${PULLREQUEST:-false}
+          ci/build-docker-image.sh --image="tuerobotics/tue-env-cuda" --branch="${BRANCH}" --commit="$GITHUB_SHA" --pull_request="${PULLREQUEST}" --user="${{ secrets.DOCKER_HUB_USERNAME }}" --password="${{ secrets.DOCKER_HUB_PASSWORD }}"
+   


### PR DESCRIPTION
In case of a PR docker build, the PR was not the PR number but just `true` (https://github.com/tue-robotics/tue-env/pull/557/checks?check_run_id=2230989984#step:4:117). This PR fixes this.

The new behaviour matches the old behaviour on Travis (https://travis-ci.com/github/tue-robotics/tue-env/jobs/447483130#L311)