### PR TITLE
Add rosdep support for missing targets

### DIFF
--- a/installer/parse-install-yaml.py
+++ b/installer/parse-install-yaml.py
@@ -107,6 +107,7 @@ def main():
                 "pip3-now",
                 "ppa-now",
                 "snap-now",
+                "rosdep",
             ]:
                 if now and "now" not in install_type:
                     install_type += "-now"

--- a/installer/tue-install-impl.bash
+++ b/installer/tue-install-impl.bash
@@ -984,7 +984,7 @@ function tue-install-snap-now
 
 function tue-install-rosdep
 {
-    tue-install-debug "tue-install-rosdep $@"
+    tue-install-debug "tue-install-rosdep $*"
 
     if [ -z "$1" ]
     then
@@ -994,9 +994,9 @@ function tue-install-rosdep
     rosdep_db=$(rosdep db --filter-for-installers=apt)  # pip extension would be nice in the future
     success=true
     system_targets=""
-    for dep in $@
+    for dep in "$@"
     do
-        system_target=$(grep -o -P "(?<=^${dep} -> ).*" <<<$rosdep_db) || { success=false; break; }
+        system_target=$(grep -o -P "(?<=^${dep} -> ).*" <<< "$rosdep_db") || { success=false; break; }
         system_targets="${system_targets} ${system_target}"
     done
 
@@ -1007,9 +1007,9 @@ function tue-install-rosdep
         rosdep_db=$(rosdep db --filter-for-installers=apt)
         system_targets=""
 
-        for dep in $@
+        for dep in "$@"
         do
-            if system_target=$(grep -o -P "(?<=^${dep} -> ).*" <<<$rosdep_db)
+            if system_target=$(grep -o -P "(?<=^${dep} -> ).*" <<< "$rosdep_db")
             then
                 system_targets="${system_targets} ${system_target}"
             else
@@ -1160,7 +1160,7 @@ function tue-install-ros
                 for dep in $deps
                 do
                     # Try installing as a target from the targets directory. Fallback to rosdep
-                    tue-install-target ${prepend}${dep} && continue
+                    tue-install-target "ros-${dep}" && continue
                     tue-install-target "$dep" && continue
                     tue-install-debug "Dependency ${dep} has no target, adding to rosdep list"
                     TUE_INSTALL_ROSDEPS="${dep} ${TUE_INSTALL_ROSDEPS}"

--- a/installer/tue-install-impl.bash
+++ b/installer/tue-install-impl.bash
@@ -982,6 +982,56 @@ function tue-install-snap-now
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
+function tue-install-rosdep
+{
+    tue-install-debug "tue-install-rosdep $@"
+
+    if [ -z "$1" ]
+    then
+        tue-install-error "Invalid tue-install-rosdep call: needs target as argument."
+    fi
+
+    rosdep_db=$(rosdep db --filter-for-installers=apt)  # pip extension would be nice in the future
+    success=true
+    system_targets=""
+    for dep in $@
+    do
+        system_target=$(grep -o -P "(?<=^${dep} -> ).*" <<<$rosdep_db) || { success=false; break; }
+        system_targets="${system_targets} ${system_target}"
+    done
+
+    failed_deps=""
+    if [ "$success" = false ]  # Try again after updating the database
+    then
+        rosdep update
+        rosdep_db=$(rosdep db --filter-for-installers=apt)
+        system_targets=""
+
+        for dep in $@
+        do
+            if system_target=$(grep -o -P "(?<=^${dep} -> ).*" <<<$rosdep_db)
+            then
+                system_targets="${system_targets} ${system_target}"
+            else
+                tue-install-debug "Cannot resolve ${dep}"
+                failed_deps="${failed_deps} ${dep}"
+            fi
+        done
+    fi
+
+    if [ -n "$failed_deps" ]
+    then
+        tue-install-error "Following dependencies could not be resolved: $failed_deps"
+        return
+    fi
+    for dep in $system_targets
+    do
+        TUE_INSTALL_SYSTEMS="${TUE_INSTALL_SYSTEMS} ${dep}"
+    done
+}
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
 function tue-install-dpkg-now
 {
     tue-install-debug "tue-install-dpkg-now $*"
@@ -1109,9 +1159,11 @@ function tue-install-ros
 
                 for dep in $deps
                 do
-                    # Preference given to target name starting with ros-
-                    tue-install-target ros-"$dep" || tue-install-target "$dep" || \
-                        tue-install-error "Targets 'ros-$dep' and '$dep' don't exist"
+                    # Try installing as a target from the targets directory. Fallback to rosdep
+                    tue-install-target ${prepend}${dep} && continue
+                    tue-install-target "$dep" && continue
+                    tue-install-debug "Dependency ${dep} has no target, adding to rosdep list"
+                    TUE_INSTALL_ROSDEPS="${dep} ${TUE_INSTALL_ROSDEPS}"
                 done
 
             else
@@ -1234,6 +1286,7 @@ TUE_INSTALL_SYSTEMS=
 TUE_INSTALL_PPA=
 TUE_INSTALL_PIP3S=
 TUE_INSTALL_SNAPS=
+TUE_INSTALL_ROSDEPS=
 
 TUE_INSTALL_WARNINGS=
 TUE_INSTALL_INFOS=
@@ -1299,6 +1352,17 @@ fi
 
 # Remove temp directories
 rm -rf "$TUE_INSTALL_STATE_DIR"
+
+
+# Installing all rosdep targets, which are collected during the install
+# (Or actually they are sneaked into the system targets)
+if [ -n "$TUE_INSTALL_ROSDEPS" ]
+then
+    TUE_INSTALL_CURRENT_TARGET="ROSDEP"
+
+    tue-install-debug "calling: tue-install-rosdep $TUE_INSTALL_ROSDEPS"
+    tue-install-rosdep "$TUE_INSTALL_ROSDEPS"
+fi
 
 
 # Installing all the ppa repo's, which are collected during install

--- a/installer/tue-install-impl.bash
+++ b/installer/tue-install-impl.bash
@@ -994,7 +994,8 @@ function tue-install-rosdep
     rosdep_db=$(rosdep db --filter-for-installers=apt)  # pip extension would be nice in the future
     success=true
     system_targets=""
-    for dep in "$@"
+    # shellcheck disable=SC2048
+    for dep in "$*"
     do
         system_target=$(grep -o -P "(?<=^${dep} -> ).*" <<< "$rosdep_db") || { success=false; break; }
         system_targets="${system_targets} ${system_target}"
@@ -1007,7 +1008,8 @@ function tue-install-rosdep
         rosdep_db=$(rosdep db --filter-for-installers=apt)
         system_targets=""
 
-        for dep in "$@"
+        # shellcheck disable=SC2048
+        for dep in $*
         do
             if system_target=$(grep -o -P "(?<=^${dep} -> ).*" <<< "$rosdep_db")
             then

--- a/setup/tue-env.bash
+++ b/setup/tue-env.bash
@@ -20,6 +20,7 @@ function tue-env
         switch         - Switch to a different environment
         config         - Configures current environment
         set-default    - Set default environment
+        unset-default  - No default environment
         init-targets   - (Re-)Initialize the target list
         targets        - Changes directory to targets directory
         list           - List all possible environments
@@ -162,6 +163,10 @@ Purged environment directory of '$env'"""
         echo "$1" > "$TUE_DIR"/user/config/default_env
         echo "[tue-env] Default environment set to $1"
 
+    elif [[ $cmd == "unset-default" ]]
+    then
+        rm "${TUE_DIR}/user/config/default_env" 2> /dev/null
+        echo "[tue-env] Unset default environment"
     elif [[ $cmd == "init-targets" ]]
     then
         if [ -z "$1" ] || { [ -z "$TUE_ENV" ] && [ -z "$2" ]; }
@@ -274,7 +279,7 @@ function _tue-env
 
     if [ "$COMP_CWORD" -eq 1 ]
     then
-        mapfile -t COMPREPLY < <(compgen -W "init list switch list-current remove cd set-default config init-targets targets" -- "$cur")
+        mapfile -t COMPREPLY < <(compgen -W "init list switch list-current remove cd set-default unset-default config init-targets targets" -- "$cur")
     else
         cmd=${COMP_WORDS[1]}
         if [[ $cmd == "switch" ]] || [[ $cmd == "remove" ]] || [[ $cmd == "cd" ]] || [[ $cmd == "set-default" ]] || [[ $cmd == "init-targets" ]] || [[ $cmd == "targets" ]]


### PR DESCRIPTION
To test: simply remove `ros-std_msgs` from your targets. That should normally break stuff I guess :sunglasses: 